### PR TITLE
Update support-for-windows-10.md

### DIFF
--- a/sccm/core/plan-design/configs/support-for-windows-10.md
+++ b/sccm/core/plan-design/configs/support-for-windows-10.md
@@ -21,27 +21,27 @@ manager: angrobe
 *Applies to: System Center Configuration Manager (Current Branch)*
 
 
- This topic details the versions of Windows 10 that you can use with the different versions of System Center Configuration Manager Current Branch. This includes:
+ This topic details the various releases of Windows 10 that you can use with the different versions of System Center Configuration Manager Current Branch. This includes:
  -  Windows 10 as Configuration Manager client.
  -  The Windows 10 Windows Assessment and Deployment Kit (ADK).
 
-## Windows 10 as a client
-Configuration Manager attempts to provide support as a client for each new Windows 10 version as soon as possible after that Windows version releases. Because the products have separate development and release schedules, the support that Configuration Manager provides depends on when the versions and branches of each product release.
+## Windows 10 as a Configuration Manager client
+Configuration Manager attempts to provide support as a client for each new Windows 10 release as soon as possible after that Windows release is made available. Because the products have separate development and release schedules, the support that Configuration Manager provides depends on when the Windows 10 release becomes available.
 
-For example, a Configuration Manager version will drop from the matrix after [support for that version](/sccm/core/servers/manage/current-branch-versions-supported) ends. Similarly, support for Windows 10 versions like the Enterprise 2015 LTSB or 1607 (CBB) will drop from the matrix when they are removed from the Configuration Manager supported configurations list. See [Deprecated operating systems](/sccm/core/plan-design/changes/removed-and-deprecated-features#deprecated-operating-systems) for more information.
+For example, a Configuration Manager version will drop from the matrix after [support for that version](/sccm/core/servers/manage/current-branch-versions-supported) ends. Similarly, support for Windows 10 releases like the Windows 10 Enterprise 2015 LTSB release or the Windows 10 1607 release will drop from the matrix when they are removed from the Configuration Manager supported configurations list. See [Deprecated operating systems](/sccm/core/plan-design/changes/removed-and-deprecated-features#deprecated-operating-systems) for more information.
 
 -   The following information supplements [Supported operating systems for clients and devices](/sccm/core/plan-design/configs/supported-operating-systems-for-clients-and-devices).
 -   If you use the Long-Term Servicing Branch of Configuration Manager, see [Supported Configurations for the Long-Term Servicing Branch](/sccm/core/understand/supported-configurations-for-ltsb).
+-   For System Center Configuration Manager current branch version support information, see [Support for System Center Configuration Manager current branch versions](/sccm/core/servers/managed/current-branch-versions-supported).
 
-|Windows 10 versions                    |Configuration Manager 1606          |Configuration Manager 1610          |    Configuration Manager 1702 |
+|Windows 10 Release                    |Configuration Manager 1606 <br />(Support Ended: 2017-07-22)          |Configuration Manager 1610 <br />(Support Ends: 2017-11-18)          |    Configuration Manager 1702 <br />(Support Ends: 2018-03-27) |
 |---------------------|-----|-----|-----|
-|Enterprise 2015 LTSB                   |![Supported](media/green_check.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
-|1507 <br />(*see editions*)            |![Supported](media/green_check.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
-|1511 (CB), (CBB)<br />(*see editions*) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
-|Enterprise 2016 LTSB                   |![Supported](media/green_check.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
-|1607 (CB)	<br />Anniversary Update<br />(*see editions*)      |![Backwards compatible](media/blue_compat.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
-|1607 (CBB)	<br />Anniversary Update<br />(*see editions*)      |![Not supported](media/Red_X.png)   |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
-|1703 (CB)	<br />Creators Update<br />(*see editions*)      |![Not supported](media/Red_X.png)   |![Not supported](media/Red_X.png) |![Backwards compatible](media/blue_compat.png) |
+|Enterprise 2015 LTSB                    |![Not supported](media/Red_X.png)    |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
+|1507 <br />(*see editions*)            |![Not supported](media/Red_X.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
+|1511 <br />(*see editions*) |![Not supported](media/Red_X.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
+|Enterprise 2016 LTSB                   |![Not supported](media/Red_X.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
+|1607 <br />Anniversary Update<br />(*see editions*)      |![Not supported](media/Red_X.png) |![Supported](media/green_check.png) |![Supported](media/green_check.png) |
+|1703 <br />Creators Update<br />(*see editions*)      |![Not supported](media/Red_X.png)   |![Not supported](media/Red_X.png) |![Backwards compatible](media/blue_compat.png) |
 
 
 **Editions:** Enterprise, Pro, Education, Pro Education   
@@ -49,7 +49,7 @@ For example, a Configuration Manager version will drop from the matrix after [su
 |Key|
 |--|
 |![Supported](media/green_check.png) = **Supported**  |
-|![Not supported](media/blue_compat.png)  = **Backwards compatible** - This means that existing client management features (hardware inventory, software inventory, software updates, etc.) should work with the new Windows 10 Current Branch build. Any known issues or caveats will be documented. <br><br>This approach gives you the ability to deploy and manage new Windows 10 CB builds on day one with application compatibility support without requiring a new Configuration Manager update version. |
+|![Not supported](media/blue_compat.png)  = **Backwards compatible** - This means that existing client management features (hardware inventory, software inventory, software updates, etc.) should work with the new Windows 10 Release. Any known issues or caveats will be documented. <br><br>This approach gives you the ability to deploy and manage new Windows 10 Release builds on "day one" with application compatibility support without requiring a new Configuration Manager update version. |
 |![Supported](media/Red_X.png) = **Not supported**|
 
 
@@ -67,6 +67,6 @@ The following table list the versions of the Windows 10 ADK that you can use wit
 
 |Key|
 |--|
-|![Supported](media/green_check.png) = **Supported** - Windows recommends using the Windows ADK that matches the version of Windows you are deploying. For example, use the Windows ADK for Windows 10 version 1703 when deploying Windows 10 version 1703.  |
+|![Supported](media/green_check.png) = **Supported** - Microsoft recommends using the version of the Windows ADK that matches the Windows version and release you are deploying. For example, use the Windows ADK for Windows 10 "1703" when deploying the Windows 10 "1703" release.  |
 |![Backwards compatible](media/blue_compat.png)  = **Backward compatible** - This combination is not tested but should work. Any known issues or caveats will be documented. |
 |![Supported](media/Red_X.png) = **Not supported**|


### PR DESCRIPTION
I am proposing three specific sets of changes to this topic. The first proposed change is to stop using the term "version" in reference to Windows 10, replacing it with the term "release" (with release used as a noun and not a verb).  

The purpose of this change is to insure we do not imply that Windows 10 has "multiple versions" when using the word “version” with Windows 10, but instead insure we are enforcing the idea that Windows 10 is in fact the last "version" of Windows (there is no "Windows 11" coming), however new capabilities and features are added to Windows over time through Feature Update "releases", where a release "becomes available" or "is generally available" (“available” is used to avoid writing that a “release” (noun) is being "released" (verb)).

The second proposed change is to update the chart and references under the “Windows as a Configuration Manager client” section to reference the support dates for the SCCM Current Branch (CB) version releases, and to update the icons for SCCM “1606” now that it has reached it’s “End of Support milestone”.  

These changes are realized through proposed changes to the icons for SCCM “1606” in the chart itself, as well as references to the actual end of Support milestone as text under each release described in the chart.  Additionally, a bullet referring readers to the Document Library topic titled “Support for System Center Configuration Manager current branch versions” is also added.  Since “support” of Windows 10 as a SCCM “client” depends on the status of each SCCM CB version release, I believe convenient reference from this topic to the “end of support” date topic is important.

The third proposed change is to remove the references to "CB" and "CBB" in relation to Windows 10 "releases". 

Documentation and discussions with Commercial Customers on the topic of Windows as a Service are moving away from the use of the "Current Branch (CB)" and "Current Branch for Business" (CBB) terminology.  Instead we (Microsoft Commercial Technical Field) are tasked with working to focus our customers on understanding that "CBB" is simply a development milestone in the life of a Windows 10 release, and they should be deploying each Semi-Annual Channel Feature Update release for Windows 10 using a process and timing that makes sense for their organization, rather than automatically having the organizational process being tied to waiting for the “CBB” development milestone just because it is titled “Current Branch for Business”. 

It is important we de-emphasize CBB as a deployment milestone for commercial customers, noting that CBB is actually a milestone in the code development of an individual Windows release that is based on a certain Quality Update being available and deployed.  We need customers to understand there is really no significant difference to Windows 10 code except for the installation of that Quality Update release that designates the CBB milestone (for example, Win 10 "1607" reaches "CBB" when the Quality Update detailed by KB 32000970 is deployed ). 

However, since SCCM CB release support for Windows 10 can be different before or after the Windows 10 release code reaches the CBB development milestone, I am proposing that any references made to CBB are avoided, and instead a reference made to the Quality Update for the Windows 10 release that brings the code to “CBB”.  This could appear in future versions of this document as a note, such as "NOTE: Backwards Compatibility Support for Windows 10 “1607” ends once Windows 10 "1607" is serviced using the Quality Update released under KB 32000970, made generally available on 2016-11-08)

I hope these proposed changes will be considered.