### PR TITLE
Update recommended-hardware.md

### DIFF
--- a/sccm/core/plan-design/configs/recommended-hardware.md
+++ b/sccm/core/plan-design/configs/recommended-hardware.md
@@ -40,7 +40,7 @@ For best performance, use RAID 10 configurations for all data drives and a 1-Gbp
 
 ###  <a name="bkmk_ScaleSiteServer"></a> Site servers  
 
-||CPU (cores)|Memory (GB)|Memory allocation for SQL Server (%)|  
+|Site configuration|CPU (cores)|Memory (GB)|Memory allocation for SQL Server (%)|  
 |-------------------------------|---------------|---------------|----------------------------------------|  
 |Stand-alone primary site server with a database site role on the same server<sup>1</sup>|16|96|80|  
 |Stand-alone primary site server with a remote site database|8|16|-|  

--- a/sccm/core/plan-design/configs/recommended-hardware.md
+++ b/sccm/core/plan-design/configs/recommended-hardware.md
@@ -40,7 +40,7 @@ For best performance, use RAID 10 configurations for all data drives and a 1-Gbp
 
 ###  <a name="bkmk_ScaleSiteServer"></a> Site servers  
 
-|Stand-alone primary site|CPU (cores)|Memory (GB)|Memory allocation for SQL Server (%)|  
+||CPU (cores)|Memory (GB)|Memory allocation for SQL Server (%)|  
 |-------------------------------|---------------|---------------|----------------------------------------|  
 |Stand-alone primary site server with a database site role on the same server<sup>1</sup>|16|96|80|  
 |Stand-alone primary site server with a remote site database|8|16|-|  


### PR DESCRIPTION
The table in the "Site server" section doesn't apply only to "Stand-alone primary site", therefore either the title for the first column should be removed or the table should be split in three: 1. Stand-alone primary site (rows 1-3), 2. Hierarchy with central administration site (rows 4-9), 3. Secondary site (row 10).