### PR TITLE
Update test-client-upgrades.md

### DIFF
--- a/sccm/core/clients/manage/upgrade/test-client-upgrades.md
+++ b/sccm/core/clients/manage/upgrade/test-client-upgrades.md
@@ -36,8 +36,10 @@ You can test a new Configuration Manager client version in a pre-production coll
 3.  Promote the new client to production.  
 
 ##  To configure automatic client upgrades to use a pre-production collection  
+> [!IMPORTANT]
+> Pre-production client deployment is not supported for workgroup computers. They can't use the authentication required for the distribution point to access the pre-production client package.  They will receive the latest client when it is promoted to be the production client.
 
-1. [Set up a collection](..\collections\create-collections.md) that contains the computers you want to deploy the pre-production client to. Don't  include workgroup computers in pre-production collections. They can't use the authentication required for the distribution point to access the pre-production client package.   
+1. [Set up a collection](..\collections\create-collections.md) that contains the computers you want to deploy the pre-production client to.   
 
 1.  In the Configuration Manager console open **Administration** > **Site Configuration** > **Sites**, and choose **Hierarchy Settings**.  
 


### PR DESCRIPTION
I think it's useful to call out the workgroup restriction more prominently and confirm that automatic upgrades will work with the production client.  Call me obtuse but it took me a few days of trying to get it to work until it took a support call to point out the existing wording.  It's also an odd restriction since the client can download the production version it seems reasonable to expect it to download the pre-production version.