### PR TITLE
Updating min supported iOS version

### DIFF
--- a/sccm/mdm/deploy-use/protect-apps-using-mam-policies.md
+++ b/sccm/mdm/deploy-use/protect-apps-using-mam-policies.md
@@ -26,7 +26,7 @@ System Center Configuration Manager application management policies let you modi
 
 -   Devices that run Android 4 and later  
 
--   Devices that run iOS 7 and later  
+-   Devices that run iOS 9 and later  
 
 You can also use mobile app management policies to protect apps on devices that are not managed by Intune. Using this new capability, you can apply mobile app management policies to apps that connect to Office 365 services. This is not supported for apps that connect to on-premises Exchange or SharePoint.  
 


### PR DESCRIPTION
Per the minimum supported platforms listed here https://github.com/MicrosoftDocs/SCCMdocs/blob/master/sccm/mdm/includes/mdm-supported-devices.md , the minimum iOS version should be 9, not 7 -- even if they do work on earlier versions.