### PR TITLE
Updating min supported iOS version

### DIFF
--- a/sccm/mdm/deploy-use/create-wifi-profiles.md
+++ b/sccm/mdm/deploy-use/create-wifi-profiles.md
@@ -30,9 +30,9 @@ You can configure the following mobile device types with Wi-Fi profiles:
 
 -   Devices that run Windows 10 Desktop or Mobile  
 
--   IPhone devices that run iOS 8  
+-   IPhone devices that run iOS 9  
 
--   IPad devices that run iOS 8  
+-   IPad devices that run iOS 9  
 
 -   Android devices that run version 4 or later
 


### PR DESCRIPTION
Per the minimum supported platforms listed here https://github.com/MicrosoftDocs/SCCMdocs/blob/master/sccm/mdm/includes/mdm-supported-devices.md , the minimum iOS version should be 9, not 8 -- even if they do work on earlier versions.