### PR TITLE
Updating min supported iOS version

### DIFF
--- a/sccm/mdm/deploy-use/create-exchange-activesync-profiles.md
+++ b/sccm/mdm/deploy-use/create-exchange-activesync-profiles.md
@@ -30,8 +30,8 @@ By using Microsoft Intune and Exchange ActiveSync, you can set up devices with e
 
 - Windows 10
 - Windows Phone 8.1
-- iPhones running iOS 8  
-- iPads running iOS 8  
+- iPhones running iOS 9 and later 
+- iPads running iOS 9 and later 
 - Samsung KNOX Standard (4 and later)
 - Android for Work
 


### PR DESCRIPTION
Per the minimum supported platforms listed here https://github.com/MicrosoftDocs/SCCMdocs/blob/master/sccm/mdm/includes/mdm-supported-devices.md , the minimum iOS version should be 9, not 7 -- even if they do work on earlier versions. I also added "and later" to match the string for Samsung KNOX.