### PR TITLE
Add RHEL 7 pre-req details with other pre-req listings

### DIFF
--- a/sccm/core/clients/deploy/plan/planning-for-client-deployment-to-linux-and-unix-computers.md
+++ b/sccm/core/clients/deploy/plan/planning-for-client-deployment-to-linux-and-unix-computers.md
@@ -65,6 +65,13 @@ You can install the System Center Configuration Manager client on computers that
 |Openssl|OpenSSL Libraries; Secure Network Communications Protocol|1.0.0-4|  
 |PAM|Pluggable Authentication Modules|1.1.1-4|  
 
+ **Red Hat Enterprise Linux Server release 7**  
+
+|Required package|Description|Minimum version|  
+|----------------------|-----------------|---------------------|  
+|glibc|C Standard Libraries|2.17|  
+|Openssl|OpenSSL Libraries; Secure Network Communications Protocol|1.0.1|  
+|PAM|Pluggable Authentication Modules|1.1.1-4|  
 
  **Solaris 10 SPARC**  
 


### PR DESCRIPTION
For unknown reasons, the SCCM documentation never listed pre-req information for RHEL 7 clients along with RHEL 5 and RHEL 6.   This omission was noted by a customer.  This change adds the missing information.