### PR TITLE
missing CmdLets

### DIFF
--- a/sccm/mdm/deploy-use/manage-mobile-devices-with-exchange-activesync.md
+++ b/sccm/mdm/deploy-use/manage-mobile-devices-with-exchange-activesync.md
@@ -104,6 +104,12 @@ Use the Exchange Server connector in System Center Configuration Manager when yo
     -   **New-ActiveSyncMailboxPolicy**  
 
     -   **Remove-ActiveSyncDevice**  
+    
+    -   **Get-CasMailbox**  
+    
+    -   **Get-User**  
+    
+    -   **Set-ActiveSyncOrganizationSettings**  
 
     > [!NOTE]  
     >  The following Exchange Server management roles include these cmdlets: Recipient Management, View-Only Organization Management, and Server Management. For more information about management role groups in Microsoft Exchange Server 2010, see [Understanding Management Role Groups](http://go.microsoft.com/fwlink/p/?LinkId=212914).  


### PR DESCRIPTION
Without these CmdLets included in the RBAC role, the Exchange connector will result in error messages like the one below on the target Exchange server and the Exchange connector will not work. This is the error, e.g. when Get-User is missing:

Log Name:      MSExchange Management
Source:        MSExchange CmdletLogs
Date:          06.03.2018 11:45:01
Event ID:      6
Task Category: General
Level:         Error
Keywords:      Classic
User:          N/A
Computer:      TestServer.TestDomain.q9-CorpDirectory-Contoso.test-Contoso.com
Description:
Cmdlet failed. Cmdlet Get-User, parameters -Identity "TestDomain.Q9-CorpDirectory-Contoso.TEST-Contoso.COM/APPLICATIONS/SCCM/USERACCOUNTS/Z_OTHERS/ScmUser".
Event Xml:
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
  <System>
    <Provider Name="MSExchange CmdletLogs" />
    <EventID Qualifiers="49152">6</EventID>
    <Level>2</Level>
    <Task>1</Task>
    <Keywords>0x80000000000000</Keywords>
    <TimeCreated SystemTime="2018-03-06T10:45:01.000000000Z" />
    <EventRecordID>25739</EventRecordID>
    <Channel>MSExchange Management</Channel>
    <Computer>TestServer.TestDomain.q9-CorpDirectory-Contoso.test-Contoso.com</Computer>
    <Security />
  </System>
  <EventData>
    <Data>Get-User</Data>
    <Data>-Identity "TestDomain.Q9-CorpDirectory-Contoso.TEST-Contoso.COM/APPLICATIONS/SCCM/USERACCOUNTS/Z_OTHERS/ScmUser"</Data>
    <Data>q9-CorpDirectory-Contoso.test-Contoso.com/fe/IT/Dept/Admins/SCCM Exchange Connector</Data>
    <Data>S-1-5-21-1333993993-3583483663-3020350646-145736</Data>
    <Data>S-1-5-21-1333993993-3583483663-3020350646-145736</Data>
    <Data>Remote-PowerShell-Unknown</Data>
    <Data>11180 w3wp#MSExchangePowerShellAppPool</Data>
    <Data>
    </Data>
    <Data>95</Data>
    <Data>00:00:00.0624269</Data>
    <Data>View Entire Forest: 'True', Configuration Domain Controller: 'DC.TestDomain.q9-CorpDirectory-Contoso.test-Contoso.com', Preferred Global Catalog: 'DC.TestDomain.q9-CorpDirectory-Contoso.test-Contoso.com', Preferred Domain Controllers: '{ DC.TestDomain.q9-CorpDirectory-Contoso.test-Contoso.com }'</Data>
    <Data>Microsoft.Exchange.Configuration.Tasks.ManagementObjectNotFoundException: The operation couldn't be performed because object 'TestDomain.Q9-CorpDirectory-Contoso.TEST-Contoso.COM/APPLICATIONS/SCCM/USERACCOUNTS/Z_OTHERS/ScmUser' couldn't be found on 'DC.TestDomain.q9-CorpDirectory-Contoso.test-Contoso.com'.
   at Microsoft.Exchange.Configuration.Tasks.Task.ThrowError(Exception exception, ErrorCategory errorCategory, Object target, String helpUrl)
   at Microsoft.Exchange.Configuration.Tasks.GetObjectWithIdentityTaskBase`2.InternalProcessRecord()
   at Microsoft.Exchange.Configuration.Tasks.GetRecipientObjectTask`2.InternalProcessRecord()
   at Microsoft.Exchange.Configuration.Tasks.Task.&lt;ProcessRecord&gt;b__b()
   at Microsoft.Exchange.Configuration.Tasks.Task.InvokeRetryableFunc(String funcName, Action func, Boolean terminatePipelineIfFailed)</Data>
    <Data>Context</Data>
    <Data>
    </Data>
    <Data>Ex6F9304</Data>
    <Data>
    </Data>
    <Data>
    </Data>
    <Data>False</Data>
    <Data>
    </Data>
    <Data>0 objects execution has been proxied to remote server.</Data>
    <Data>
    </Data>
    <Data>
    </Data>
    <Data>0</Data>
    <Data>ActivityId: 69cd1087-2030-4bce-9e80-42379766dc57</Data>
    <Data>ServicePlan:;IsAdmin:True;</Data>
    <Data>
    </Data>
    <Data>en-US</Data>
  </EventData>
</Event>