### PR TITLE
Update sms_updatecompliancestatus-server-wmi-class.md

### DIFF
--- a/sccm/develop/reference/sum/sms_updatecompliancestatus-server-wmi-class.md
+++ b/sccm/develop/reference/sum/sms_updatecompliancestatus-server-wmi-class.md
@@ -12,7 +12,9 @@ ms.tgt_pltfrm: ""
 ms.topic: "article"
 applies_to:
   - "System Center Configuration Manager (current branch)"
-ms.assetid: f7789fb5-fa96-4e88-8737-9adcb0498c4fsearchScope: - ConfigMgr SDK
+ms.assetid: f7789fb5-fa96-4e88-8737-9adcb0498c4f
+searchScope:
+ - ConfigMgr SDK
 caps.latest.revision: 15
 author: "shill-ms"
 ms.author: "v-suhill"
@@ -191,7 +193,14 @@ Class SMS_UpdateComplianceStatus : SMS_BaseClass
 
  Qualifiers: [read, not_null]  
 
- The status of the target computer.  
+ The status of the target computer.  Possible values are:  
+
+|||  
+|-|-|  
+|0|Detection state unknown|  
+|1|Update is not required|  
+|2|Update is required|  
+|3|Update is installed| 
 
  `UpdateLocales`  
  Data type: `String`  


### PR DESCRIPTION
Add possible values for the status field based on the assumed equivalent view (v_updateComplianceStatus)

Note: The basic GitHub compare screen seemed to suggest I modified almost the entire page.  I only added a few lines to the documentation for that status field which the 'rich comparison' feature shows.  I'll be perfectly happy if it's cleaner for you to just copy and paste the added lines into the master and close this PR.