### PR TITLE
Update manage-express-installation-files-for-windows-10-updates.md

### DIFF
--- a/sccm/sum/deploy-use/manage-express-installation-files-for-windows-10-updates.md
+++ b/sccm/sum/deploy-use/manage-express-installation-files-for-windows-10-updates.md
@@ -3,7 +3,9 @@ title: Manage Express installation files for Windows 10 updates
 titleSuffix: "Configuration Manager"
 description: "Configuration Manager supports express installation files for Windows 10, which provides smaller downloads and faster installation times on clients."
 keywords:
-author: dougebyms.author: dougebymanager: angrobe
+author: dougeby
+ms.author: dougeby
+manager: angrobe
 ms.date: 03/24/2017
 ms.topic: article
 ms.prod: configuration-manager
@@ -14,7 +16,7 @@ ms.assetid: b8d8af88-e8ac-4deb-921b-975e2d2afd80
 ---
 
 # Manage Express installation files for Windows 10 updates
-Beginning in Configuration Manager version 1702, Configuration Manager supports express installation files for Windows 10 updates. When you use a supported version of Windows 10, you can use Configuration Manager settings to download only the changes between the current month's Windows 10 Cumulative Update and the previous month's update. Without express installation files, Configuration Manager downloads the full Windows 10 Cumulative Update (including all updates from previous months) each month. Using express installation files provides for smaller downloads and faster installation times on clients.
+Beginning in Configuration Manager version 1702, Configuration Manager supports express installation files for Windows 10 updates. When you use a supported version of Windows 10, you can use Configuration Manager client settings to configure the client to download only the changes between the current month's Windows 10 Cumulative Update and the previous month's update. Without express installation files, Configuration Manager clients download the full Windows 10 Cumulative Update (including all updates from previous months) each month. Using express installation files provides for smaller downloads and faster installation times on clients.
 
 > [!IMPORTANT]
 > While the settings to support the use of express installation files is available in Configuration Manager version 1702, the operating system client support is available in Windows 10 version 1607 with a Windows Update Agent update. This update is included with the updates released on April 11, 2017 (Patch Tuesday). For more information about these updates, see [support article 4015217](http://support.microsoft.com/kb/4015217). Future updates will leverage express for smaller downloads. Windows 10 version 1607 without the update and prior versions do not support express installation files.
@@ -24,7 +26,10 @@ Beginning in Configuration Manager version 1702, Configuration Manager supports 
 To start synchronizing the metadata for Windows 10 express installation files, you must enable it in the Software Update Point Properties.
 1.	In the Configuration Manager console, navigate to **Administration** > **Site Configuration** > **Sites**.
 2.	Select the central administration site or the stand-alone primary site.
-3.	On the **Home** tab, in the **Settings** group, click **Configure Site Components**, and then click **Software Update Point**. On the **Update Files** tab, select **Download full files for all approved updates and express installation files for Windows 10**.
+3.	On the **Home** tab, in the **Settings** group, click **Configure Site Components**, and then click **Software Update Point**. On the **Update Files** tab, select **Download both full files for all approved updates and express installation files for Windows 10**.
+
+> [!NOTE]    
+> You cannot configure the Software Update Point component to only download express updates.  Downloading the express installation files will be in addition to the full files and thus will increase the amount of content distributed to and stored on your distribution points.
 
 ### To enable support for clients to download and install express installation files
 To enable express installation files support on clients, you must enable express installation files in the Software Updates section of client settings. This creates a new HTTP listener that listens for requests to download express installation files on the port that you specify.


### PR DESCRIPTION
I see a lot of people misunderstanding what problem express installation files solve.  Many are shocked to learn that it only increases the demand on their WAN links to the DPs and the storage space required.  Express files only improve a last-mile client function which hopefully these edits help to clarify.