### PR TITLE
Add KeySize Note into: example-deployment-of-pki-certificates.md

### DIFF
--- a/sccm/core/plan-design/network/example-deployment-of-pki-certificates.md
+++ b/sccm/core/plan-design/network/example-deployment-of-pki-certificates.md
@@ -242,6 +242,9 @@ This certificate deployment has the following procedures:
 
 9. Select the **Enroll** permission for this group, and do not clear the **Read** permission.  
 
+    > [!NOTE]
+    > Ensure that **Minimum key size** on the **Cryptography** tab has been set to **2048**
+
 10. Choose **OK**, and then close **Certificate Templates Console**.  
 
 11. In the Certification Authority console, right-click **Certificate Templates**, choose **New**, and then choose **Certificate Template to Issue**.  


### PR DESCRIPTION
As discussed with Aaron, found that older Cert Authorities had a base line of below 2048 keys. which are not compatible with SCCM Cloud solutions (CDP & CMG)