### PR TITLE
Update triggerschedule-method-in-class-sms_client.md

### DIFF
--- a/sccm/develop/reference/core/clients/client-classes/triggerschedule-method-in-class-sms_client.md
+++ b/sccm/develop/reference/core/clients/client-classes/triggerschedule-method-in-class-sms_client.md
@@ -31,31 +31,204 @@ UInt32 TriggerSchedule(
 
  GUID of the schedule to be triggered.  
 
- Example GUIDs:  
+ Complete GUID List:  
 
- Hardware Inventory  
+ Hardware Inventory
 
- {00000000-0000-0000-0000-000000000001}  
+{00000000-0000-0000-0000-000000000001}
 
- Software Inventory  
+Software Inventory
 
- {00000000-0000-0000-0000-000000000002}  
+{00000000-0000-0000-0000-000000000002}
 
- Data Discovery Record  
+Data Discovery Record
 
- {00000000-0000-0000-0000-000000000003}  
+{00000000-0000-0000-0000-000000000003}
 
- File Collection  
+File Collection
 
- {00000000-0000-0000-0000-000000000010}  
+{00000000-0000-0000-0000-000000000010}
 
- Machine Policy Assignments Request  
+IDMIF Collection
 
- {00000000-0000-0000-0000-000000000021}  
+{00000000-0000-0000-0000-000000000011}
 
- Machine Policy Evaluation  
+Client Machine Authentication
 
- {00000000-0000-0000-0000-000000000022}  
+{00000000-0000-0000-0000-000000000012}
+
+Machine Policy Assignments Request
+
+{00000000-0000-0000-0000-000000000021}
+
+Machine Policy Evaluation
+
+{00000000-0000-0000-0000-000000000022}
+
+Refresh Default MP Task
+
+{00000000-0000-0000-0000-000000000023}
+
+LS (Location Service) Refresh Locations Task
+
+{00000000-0000-0000-0000-000000000024}
+
+LS (Location Service) Timeout Refresh Task
+
+{00000000-0000-0000-0000-000000000025}
+
+Policy Agent Request Assignment (User)
+
+{00000000-0000-0000-0000-000000000026}
+
+Policy Agent Evaluate Assignment (User)
+
+{00000000-0000-0000-0000-000000000027}
+
+Software Metering Generating Usage Report
+
+{00000000-0000-0000-0000-000000000031}
+
+Source Update Message
+
+{00000000-0000-0000-0000-000000000032}
+
+Clearing proxy settings cache
+
+{00000000-0000-0000-0000-000000000037}
+
+Machine Policy Agent Cleanup
+
+{00000000-0000-0000-0000-000000000040}
+
+User Policy Agent Cleanup
+
+{00000000-0000-0000-0000-000000000041}
+
+Policy Agent Validate Machine Policy / Assignment
+
+{00000000-0000-0000-0000-000000000042}
+
+Policy Agent Validate User Policy / Assignment
+
+{00000000-0000-0000-0000-000000000043}
+
+Retrying/Refreshing certificates in AD on MP
+
+{00000000-0000-0000-0000-000000000051}
+
+Peer DP Status reporting
+
+{00000000-0000-0000-0000-000000000061}
+
+Peer DP Pending package check schedule
+
+{00000000-0000-0000-0000-000000000062}
+
+SUM Updates install schedule
+
+{00000000-0000-0000-0000-000000000063}
+
+NAP action
+
+{00000000-0000-0000-0000-000000000071}
+
+Hardware Inventory Collection Cycle
+
+{00000000-0000-0000-0000-000000000101}
+
+Software Inventory Collection Cycle
+
+{00000000-0000-0000-0000-000000000102}
+
+Discovery Data Collection Cycle
+
+{00000000-0000-0000-0000-000000000103}
+
+File Collection Cycle
+
+{00000000-0000-0000-0000-000000000104}
+
+IDMIF Collection Cycle
+
+{00000000-0000-0000-0000-000000000105}
+
+Software Metering Usage Report Cycle
+
+{00000000-0000-0000-0000-000000000106}
+
+Windows Installer Source List Update Cycle
+
+{00000000-0000-0000-0000-000000000107}
+
+Software Updates Assignments Evaluation Cycle
+
+{00000000-0000-0000-0000-000000000108}
+
+Branch Distribution Point Maintenance Task
+
+{00000000-0000-0000-0000-000000000109}
+
+DCM policy
+
+{00000000-0000-0000-0000-000000000110}
+
+Send Unsent State Message
+
+{00000000-0000-0000-0000-000000000111}
+
+State System policy cache cleanout
+
+{00000000-0000-0000-0000-000000000112}
+
+Scan by Update Source
+
+{00000000-0000-0000-0000-000000000113}
+
+Update Store Policy
+
+{00000000-0000-0000-0000-000000000114}
+
+State system policy bulk send high
+
+{00000000-0000-0000-0000-000000000115}
+
+State system policy bulk send low
+
+{00000000-0000-0000-0000-000000000116}
+
+AMT Status Check Policy
+
+{00000000-0000-0000-0000-000000000120}
+
+Application manager policy action
+
+{00000000-0000-0000-0000-000000000121}
+
+Application manager user policy action
+
+{00000000-0000-0000-0000-000000000122}
+
+Application manager global evaluation action
+
+{00000000-0000-0000-0000-000000000123}
+
+Power management start summarizer
+
+{00000000-0000-0000-0000-000000000131}
+
+Endpoint deployment reevaluate
+
+{00000000-0000-0000-0000-000000000221}
+
+Endpoint AM policy reevaluate
+
+{00000000-0000-0000-0000-000000000222}
+
+External event detection
+
+{00000000-0000-0000-0000-000000000223}
+
 
 ## Return Values  
  A `UInt32` data type that is 0 to indicate success or non-zero to indicate failure.  


### PR DESCRIPTION
I'm not sure if all of the GUIDs are valid. I got the list from here: https://blogs.technet.microsoft.com/charlesa_us/2015/03/07/triggering-configmgr-client-actions-with-wmic-without-pesky-right-click-tools/. I have been looking for an official source for the complete GUID list, so I thought this may be a good place for them. Not sure it fits the structure of the SDK, but it would be nice to have a complete GUID list somewhere. 

Additionally, the names of the actions may not be the "official" names. Just using what I could find.