### PR TITLE
Change "Windows Reccomends" to "Microsoft Reccomends" under Widnos AD…

### DIFF
--- a/sccm/core/plan-design/configs/support-for-windows-10.md
+++ b/sccm/core/plan-design/configs/support-for-windows-10.md
@@ -73,7 +73,7 @@ The following table lists the versions of the Windows 10 ADK that you can use wi
 
 |Key|
 |--|
-| ![Supported](media/green_check.png) = **Supported** <br/> Windows recommends using the Windows ADK that matches the version of Windows you're deploying. For example, use the Windows ADK for Windows 10 version 1703 when deploying Windows 10 version 1703. For more information on Windows ADK component supportability, see [DISM supported platforms](https://docs.microsoft.com/windows-hardware/manufacture/desktop/dism-supported-platforms) and [USMT requirements](https://docs.microsoft.com/windows/deployment/usmt/usmt-requirements#bkmk-1). |
+| ![Supported](media/green_check.png) = **Supported** <br/> Microsoft recommends using the Windows ADK that matches the version of Windows you're deploying. For example, use the Windows ADK for Windows 10 version 1703 when deploying Windows 10 version 1703. For more information on Windows ADK component supportability, see [DISM supported platforms](https://docs.microsoft.com/windows-hardware/manufacture/desktop/dism-supported-platforms) and [USMT requirements](https://docs.microsoft.com/windows/deployment/usmt/usmt-requirements#bkmk-1). |
 | ![Backwards compatible](media/blue_compat.png)  = **Backward compatible** <br/> This combination isn't tested but should work. We will document any known issues or caveats. |
 | ![Not supported](media/Red_X.png) = **Not supported** |
 


### PR DESCRIPTION
…K supported comments

While this proposed change is perhaps a bit "nit picky", I believe it makes more sense to say "Microsoft recommends" in this sentence to indicate that this is the guidance from Microsoft, since "Windows" is used to refer to the Windows OS software later in the same sentence.  The sentence as it is written today suggests that "Windows" is recommending the ADK match the version of "Windows" being used.  I suggest that using "Microsoft" instead would better indicate it is Microsoft personnel with knowledge of the subject who are making the recommendation.  Thanks for considering this proposed change.