### PR TITLE
Amended copy

### DIFF
--- a/sccm/sum/deploy-use/manage-office-365-proplus-updates.md
+++ b/sccm/sum/deploy-use/manage-office-365-proplus-updates.md
@@ -62,7 +62,7 @@ For previous Configuration Manager versions, you must take the following steps t
 
 ### Requirements
 - The computer that runs the Office 365 Installer must have Internet access.  
-- The user that runs the Office 365 Installer must have **Read** and **Write** access to the content location share is provided in the wizard.
+- The user that runs the Office 365 Installer must have **Read** and **Write** access to the content location share provided in the wizard.
 - If you receive a 404 download error, copy the following files to the user %temp% folder:
   - [releasehistory.xml](http://officecdn.microsoft.com/pr/wsus/releasehistory.cab)
   - [o365client_32bit.xml](http://officecdn.microsoft.com/pr/wsus/ofl.cab)  


### PR DESCRIPTION
Grammar change. Updated the line 'The user that runs the Office 365 Installer must have **Read** and **Write** access to the content location share is provided in the wizard.' to remove the word is.