### PR TITLE
Update to better refelct post 1710 Support lifecycle

### DIFF
--- a/sccm/core/plan-design/changes/whats-new-incremental-versions.md
+++ b/sccm/core/plan-design/changes/whats-new-incremental-versions.md
@@ -28,7 +28,7 @@ manager: dougeby
   - [What's new in version 1706](../../../core/plan-design/changes/whats-new-in-version-1706.md)  
 
 
- Each update version is supported for a year after its release. Stay current with the most recent update version. For more information, see [Support for Configuration Manager current branch versions](../../../core/servers/manage/current-branch-versions-supported.md).  
+For versions of Configuration Manager released prior to 1710, support is for 12 months. Beginning with the 1710 release, each update version remains in support for 18 months from its general availability (GA) release date.  Stay current with the most recent update version. For more information, see [Support for Configuration Manager current branch versions](../../../core/servers/manage/current-branch-versions-supported.md).  
 
 
 ## See also


### PR DESCRIPTION
Proposed change replaces text indicating 12 months of support with text referring to 18 months support beginning with the 1710 CM CB release (Aaron - similar to the change proposed earlier in the other topic )