### PR TITLE
Update packages-and-programs.md

### DIFF
--- a/sccm/apps/deploy-use/packages-and-programs.md
+++ b/sccm/apps/deploy-use/packages-and-programs.md
@@ -207,7 +207,7 @@ Packages can use some new features of Configuration Manager, including distribut
         -   **Required**: The package and program is deployed automatically, according to the configured schedule. However, a user can track the package and program deployment status and install it before the deadline by using Software Center.  
 
         >  [!NOTE]  
-        >  Package and task sequence deployments may not appear in software center if multiple users are logged into the device.
+        >  If multiple users are signed into the device, package and task sequence deployments may not appear in Software Center.
         
     -   **Send wake-up packets**: If the deployment purpose is set to **Required** and this option is selected, a wake-up packet is sent to computers before the deployment is installed to wake the computer from sleep at the installation deadline time. Before you can use this option, computers must be configured for Wake On LAN.  
 

--- a/sccm/apps/deploy-use/packages-and-programs.md
+++ b/sccm/apps/deploy-use/packages-and-programs.md
@@ -11,7 +11,10 @@ author: aczechowski
 manager: dougeby
 ms.author: aaroncz
 ---
-# Packages and programs in System Center Configuration Manager*Applies to: System Center Configuration Manager (Current Branch)*
+# Packages and programs in System Center Configuration Manager
+
+*Applies to: System Center Configuration Manager (Current Branch)*
+
 System Center Configuration Manager continues to support packages and programs that were used in Configuration Manager 2007. A deployment that uses packages and programs might be more suitable than a deployment that uses an application when you deploy any of the following:  
 
 - Applications to Linux and UNIX servers
@@ -203,6 +206,9 @@ Packages can use some new features of Configuration Manager, including distribut
 
         -   **Required**: The package and program is deployed automatically, according to the configured schedule. However, a user can track the package and program deployment status and install it before the deadline by using Software Center.  
 
+        >  [!NOTE]  
+        >  Package and task sequence deployments may not appear in software center if multiple users are logged into the device.
+        
     -   **Send wake-up packets**: If the deployment purpose is set to **Required** and this option is selected, a wake-up packet is sent to computers before the deployment is installed to wake the computer from sleep at the installation deadline time. Before you can use this option, computers must be configured for Wake On LAN.  
 
     -  **Allow clients on a metered Internet connection to download content after the installation deadline, which might incur additional costs**: Select this if it's required.  


### PR DESCRIPTION
Document the undocumented feature that package and task sequence deployments do not appear when multiple users are logged into the device.
[Note, not sure what the online editor did to the header but I did not intentionally change that]