### PR TITLE
Update note for supersedence auto upgrade

### DIFF
--- a/sccm/apps/deploy-use/deploy-applications.md
+++ b/sccm/apps/deploy-use/deploy-applications.md
@@ -96,7 +96,7 @@ On the **Deployment Settings** page of the Deploy Software wizard, specify the f
 - **Automatically upgrade any superseded version of this application**: The client upgrades any superseded version of the application with the superseding application.    
 
     > [!NOTE]  
-    > Starting in version 1802, for either **Available** or **Required** install purpose, you can enable or disable this option. <!--1351266--> 
+    > Starting in version 1802, for **Available** install purpose, you can enable or disable this option. <!--1351266--> 
 
 
 ### Specify scheduling settings for the deployment


### PR DESCRIPTION
The note for the option "Automatically upgrade any superseded version of this application" stated this option could be enabled or disabled for both available and required deployments, starting in version 1802. This does not seem to be the case as the option is automatically enabled and greyed out preventing any changes for reguired deployments.