### PR TITLE
Rename Sharepoint to Skype

### DIFF
--- a/sccm/mdm/deploy-use/manage-access-to-services.md
+++ b/sccm/mdm/deploy-use/manage-access-to-services.md
@@ -121,7 +121,7 @@ Conditional access to Exchange on-premises supports:
 
 
 ## Requirements for Skype for Business Online
-Conditional access to SharePoint Online supports devices that run:
+Conditional access to Skype Online supports devices that run:
  -   iOS 7.1 and later
  -   Android 4.0 and later
  -   Samsung KNOX Standard 4.0 or later


### PR DESCRIPTION
## Requirements for Skype for Business Online
Conditional access to SharePoint Online supports devices that run:

If this is truly meant to be a skype section then the SharePoint name should be changed.

## Requirements for Skype for Business Online
Conditional access to Skype Online supports devices that run: