### PR TITLE
Fixed Tables with Single Blank Headers

### DIFF
--- a/sccm/develop/reference/compliance/sms_dcmdeploymentcompliantdetailsperasset-server-wmi-class.md
+++ b/sccm/develop/reference/compliance/sms_dcmdeploymentcompliantdetailsperasset-server-wmi-class.md
@@ -275,7 +275,7 @@ Class SMS_DCMDeploymentCompliantDetailsPerAsset : SMS_BaseClass
 
  Represents the state of the rule reported by the asset. Possible values are:  
 
-||  
+|Value|
 |-|  
 |Compliant|  
 |Non-compliant|  
@@ -291,7 +291,7 @@ Class SMS_DCMDeploymentCompliantDetailsPerAsset : SMS_BaseClass
 
  Represents the sub state of the rule reported by the asset. Possible values are:  
 
-||  
+|Value|
 |-|  
 |Not-Applicable|  
 |Not-Detected|  

--- a/sccm/develop/reference/core/clients/collections/sms_combineddeviceresources-server-wmi-class.md
+++ b/sccm/develop/reference/core/clients/collections/sms_combineddeviceresources-server-wmi-class.md
@@ -268,7 +268,7 @@ Class SMS_CombinedDeviceResources : SMS_CombinedResources
 
  Used by the Exchange connector. Possible values are:  
 
-||  
+|Value|
 |-|  
 |Allowed|  
 |Blocked|  

--- a/sccm/develop/reference/core/clients/deploy/sms_clientdeploymentcollectionbucket-server-wmi-class.md
+++ b/sccm/develop/reference/core/clients/deploy/sms_clientdeploymentcollectionbucket-server-wmi-class.md
@@ -56,7 +56,7 @@ Class SMS_ClientDeploymentCollectionBucket: SMS_BaseClass
 
  The client deployment status bucket. Possible values are:  
 
-||  
+|Value|
 |-|  
 |CDUnknown|  
 |CDFullCompliant|  

--- a/sccm/develop/reference/core/clients/sdk/ccm_appdeploymenttype-client-wmi-class.md
+++ b/sccm/develop/reference/core/clients/sdk/ccm_appdeploymenttype-client-wmi-class.md
@@ -78,7 +78,7 @@ Class CCM_AppDeploymentType : CCM_SoftwareBase
 
  Applicability state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |Unknown|  
 |Applicable|  
@@ -192,7 +192,7 @@ Class CCM_AppDeploymentType : CCM_SoftwareBase
 
  Installation state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |NotInstalled|  
 |Unknown|  
@@ -255,7 +255,7 @@ Class CCM_AppDeploymentType : CCM_SoftwareBase
 
  Post installation action. Possible values are:   
 
-||  
+|Value|
 |-|  
 |NoAction|  
 |BasedOnExitCode|  
@@ -290,7 +290,7 @@ Class CCM_AppDeploymentType : CCM_SoftwareBase
 
  Resolved state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |None|  
 |NotInstalled|  
@@ -324,7 +324,7 @@ Class CCM_AppDeploymentType : CCM_SoftwareBase
 
  Supersession state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |Unknown|  
 |None|  

--- a/sccm/develop/reference/core/clients/sdk/ccm_application-client-wmi-class.md
+++ b/sccm/develop/reference/core/clients/sdk/ccm_application-client-wmi-class.md
@@ -104,7 +104,7 @@ Class CCM_Application : CCM_SoftwareBase
 
  Applicability state. Possible values are:   
 
-||  
+|Value|
 |-|  
 |Unknown|  
 |Applicable|  
@@ -119,7 +119,7 @@ Class CCM_Application : CCM_SoftwareBase
 
  Configure state. Possible values are:   
 
-||  
+|Value|
 |-|  
 |NotNeeded|  
 |NotConfigured|  
@@ -298,7 +298,7 @@ Class CCM_Application : CCM_SoftwareBase
 
  Installation state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |NotInstalled|  
 |Unknown|  
@@ -425,7 +425,7 @@ Class CCM_Application : CCM_SoftwareBase
 
  Resolved state.    
 
-||  
+|Value|
 |-|  
 |None|  
 |NotInstalled|  
@@ -469,7 +469,7 @@ Class CCM_Application : CCM_SoftwareBase
 
  Supersession state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |Unknown|  
 |None|  

--- a/sccm/develop/reference/core/clients/sdk/ccm_applicationpolicy-client-wmi-class.md
+++ b/sccm/develop/reference/core/clients/sdk/ccm_applicationpolicy-client-wmi-class.md
@@ -67,7 +67,7 @@ Class CCM_ApplicationPolicy : CCM_SoftwareBase
 
  Applicability state. Possible values are:   
 
-||  
+|Value|
 |-|  
 |Unknown|  
 |Applicable|  
@@ -91,7 +91,7 @@ Class CCM_ApplicationPolicy : CCM_SoftwareBase
 
  Configure state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |NotNeeded|  
 |NotConfigured|  
@@ -115,7 +115,7 @@ Class CCM_ApplicationPolicy : CCM_SoftwareBase
 
  Current state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |NotInstalled|  
 |Unknown|  
@@ -260,7 +260,7 @@ Class CCM_ApplicationPolicy : CCM_SoftwareBase
 
  Progress state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |Idle|  
 |EvaluationStarted|  
@@ -287,7 +287,7 @@ Class CCM_ApplicationPolicy : CCM_SoftwareBase
 
  Resolved state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |None|  
 |NotInstalled|  

--- a/sccm/develop/reference/core/clients/sdk/ccm_cievaluationjob-client-wmi-class.md
+++ b/sccm/develop/reference/core/clients/sdk/ccm_cievaluationjob-client-wmi-class.md
@@ -91,7 +91,7 @@ Class CCM_CIEvaluationJob :
 
  Job state. Possible values are:    
 
-||  
+|Value|
 |-|  
 |Idle|  
 |Evaluating|  
@@ -126,7 +126,7 @@ Class CCM_CIEvaluationJob :
 
  Job type. Possible values are:   
 
-||  
+|Value|
 |-|  
 |DesiredConfiguration|  
 |ApplicationManagement|  

--- a/sccm/develop/reference/core/clients/sdk/downloadcontents-method-in-class-ccm_application.md
+++ b/sccm/develop/reference/core/clients/sdk/downloadcontents-method-in-class-ccm_application.md
@@ -57,7 +57,7 @@ uint32 DownloadContents
 
  Priority. Possible values are:   
 
-||  
+|Value|
 |-|  
 |Foreground|  
 |High|  

--- a/sccm/develop/reference/core/clients/sdk/evaluateapppolicy-method-in-class-ccm_applicationpolicy.md
+++ b/sccm/develop/reference/core/clients/sdk/evaluateapppolicy-method-in-class-ccm_applicationpolicy.md
@@ -60,7 +60,7 @@ uint32 EvaluateAppPolicy
 
  Priority. Possible values are:   
 
-||  
+|Value|
 |-|  
 |Foreground|  
 |High|  

--- a/sccm/develop/reference/core/clients/sdk/install-method-in-class-ccm_application.md
+++ b/sccm/develop/reference/core/clients/sdk/install-method-in-class-ccm_application.md
@@ -72,7 +72,7 @@ uint32 Install
 
  Priority. Possible values are:   
 
-||  
+|Value|
 |-|  
 |Foreground|  
 |High|  

--- a/sccm/develop/reference/core/clients/sdk/uninstall-method-in-class-ccm_application.md
+++ b/sccm/develop/reference/core/clients/sdk/uninstall-method-in-class-ccm_application.md
@@ -72,7 +72,7 @@ uint32 Uninstall
 
  Priority. Possible values are:   
 
-||  
+|Value|
 |-|  
 |Foreground|  
 |High|  

--- a/sccm/develop/reference/core/servers/configure/sms_azureservice-server-wmi-class.md
+++ b/sccm/develop/reference/core/servers/configure/sms_azureservice-server-wmi-class.md
@@ -82,7 +82,7 @@ Class SMS_AzureService : SMS_BaseClass
 
  Deployment slot. Possible values are:  
 
-||  
+|Value|
 |-|  
 |Production|  
 |Staging|  
@@ -105,7 +105,7 @@ Class SMS_AzureService : SMS_BaseClass
 
  Flags for configuring the Windows Azure service. Possible values are:  
 
-||  
+|Value|
 |-|  
 |WAD_LOGS_DONT_DELETE(0)|  
 

--- a/sccm/develop/reference/core/servers/configure/sms_sci_sqltask-server-wmi-class.md
+++ b/sccm/develop/reference/core/servers/configure/sms_sci_sqltask-server-wmi-class.md
@@ -158,7 +158,7 @@ Class SMS_SCI_SQLTask : SMS_SiteControlItem
 
  Configuration Manager-defined task name. Possible values are listed below. The default value is "".  
 
-||  
+|Value|
 |-|  
 |Backup SMS Site Server|  
 |Check Application Title with Inventory Information|  

--- a/sccm/develop/reference/misc/sms_sci_roamingboundary-server-wmi-class.md
+++ b/sccm/develop/reference/misc/sms_sci_roamingboundary-server-wmi-class.md
@@ -119,7 +119,7 @@ Class SMS_SCI_RoamingBoundary : SMS_SiteControlItem
 
  Type of the roaming boundary. Possible values are:  
 
-||  
+|Value|
 |-|  
 |IP Subnets|  
 |AD Site Name|  

--- a/sccm/develop/reference/osd/sms_tasksequence_downloadpackagecontentaction-server-wmi-class.md
+++ b/sccm/develop/reference/osd/sms_tasksequence_downloadpackagecontentaction-server-wmi-class.md
@@ -96,7 +96,7 @@ Class SMS_TaskSequence_DownloadPackageContentAction : SMS_TaskSequence_Action
 
  The destination location type. The default value is TSCache. Possible values are:  
 
-||  
+|Value|
 |-|  
 |TSCache|  
 |CCMCache|  

--- a/sccm/develop/reference/osd/sms_tasksequence_pointer-server-wmi-class.md
+++ b/sccm/develop/reference/osd/sms_tasksequence_pointer-server-wmi-class.md
@@ -88,7 +88,7 @@ Class SMS_TaskSequence_Pointer : SMS_TaskSequence_Step
 
  The supported environment. The default value is WinPEandFullOS. Possible values are:  
 
-||  
+|Value|
 |-|  
 |WinPE|  
 |FullOS|  

--- a/sccm/develop/reference/osd/sms_winpeoptionalcomponentinfo-server-wmi-class.md
+++ b/sccm/develop/reference/osd/sms_winpeoptionalcomponentinfo-server-wmi-class.md
@@ -45,7 +45,7 @@ Class SMS_WinPEOptionalComponentInfo : SMS_BaseClass
 
  The architecture of WinPE optional components. Possible values are:  
 
-||  
+|Value|
 |-|  
 |X86|  
 |X64|  


### PR DESCRIPTION
Tables in markdown that have only a single column and no header are showing up as plain text when rendered.  Added header column so that they'd each show as an actual table as intended.