### PR TITLE
URL fix for using task sequence variables

### DIFF
--- a/sccm/core/plan-design/changes/whats-new-in-version-1806.md
+++ b/sccm/core/plan-design/changes/whats-new-in-version-1806.md
@@ -414,7 +414,7 @@ These task sequences can be for OS deployment or custom. It's also supported for
 #### Revised documentation for task sequence variables
  ***[Updated]*** Two new articles are now available for understanding task sequence variables:  
 
- - [How to use task sequence variables](/sccm/osd/understand/task-sequence-variables) is a new article that describes the different types of variables, methods to set the variables, and how to access them.  
+ - [How to use task sequence variables](/sccm/osd/understand/using-task-sequence-variables) is a new article that describes the different types of variables, methods to set the variables, and how to access them.  
 
  - [Task sequence variables](/sccm/osd/understand/task-sequence-variables) is a reference for all available task sequence variables. This article combines the previous articles, which separated built-in variables from action variables. 
 


### PR DESCRIPTION
In the section "Revised documentation for task sequence variables", both links were pointing to the same URL.  My change is to change the first link to the correct URL.