### PR TITLE
Updating MDM support to "Windows Holographic for Business"

### DIFF
--- a/sccm/mdm/includes/mdm-supported-devices.md
+++ b/sccm/mdm/includes/mdm-supported-devices.md
@@ -5,7 +5,7 @@
 - PCs running Windows 10 (Home, Pro, Education, and Enterprise versions)
 - Devices running Windows 10 IoT Enterprise (x86, x64)
 - Devices running Windows 10 IoT Mobile Enterprise
-- Windows Holographic & Windows Holographic Enterprise
+- Windows Holographic for Business
 - Mac OS X 10.9 and later
 - Windows Phone 8.1, PCs running Windows 8.1, and Windows 8.1 RT are in sustaining mode (Windows Embedded 8.1 Handheld is not supported)
 


### PR DESCRIPTION
The previous wording refers to Windows Holographic as having MDM support, but it does not (see Note in https://docs.microsoft.com/en-us/hololens/hololens-enroll-mdm). The branding for the OS that comes licensed with the MDM-supported commercial edition is "Windows Holographic for Business" (see https://docs.microsoft.com/en-us/hololens/hololens-upgrade-enterprise).