### PR TITLE
Script examples were broken - can't use non-existing folder

### DIFF
--- a/sccm/sum/deploy-use/service-a-server-group.md
+++ b/sccm/sum/deploy-use/service-a-server-group.md
@@ -59,7 +59,7 @@ The server group settings are configured in the properties for a device collecti
     >   
     >  `Write-Output "Universal Time: " + $a.ToUniversalTime()  |`  
     >   
-    >  `Out-File C:\temp\start.txt`  
+    >  `Out-File C:\Windows\Temp\start.txt`  
     >   
     >  **Post-deployment**  
     >   
@@ -69,7 +69,7 @@ The server group settings are configured in the properties for a device collecti
     >   
     >  `Write-Output "Universal Time: " + $a.ToUniversalTime()  |`  
     >   
-    >  `Out-File C:\temp\end.txt`  
+    >  `Out-File C:\Windows\Temp\end.txt`  
 
 ## Deploy software updates to the server group and monitor status  
 You deploy software updates to the server group collection by using the typical deployment process. After you deploy the software updates, you can monitor the software update deployment in the Configuration Manager console.


### PR DESCRIPTION
Changed from C:\Temp\End.txt to C:\Windows\Temp\end.txt...  otherwise the script will fail if the Temp folder doesn't already exist!

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)

@Article_Author please review (look at the `author` metadata tag)