### PR TITLE
Added link to sms_advertisement class

### DIFF
--- a/sccm/develop/core/servers/configure/how-to-create-an-advertisement.md
+++ b/sccm/develop/core/servers/configure/how-to-create-an-advertisement.md
@@ -11,7 +11,7 @@ ms.author: aaroncz
 manager: dougeby
 ---
 # How to Create an Advertisement
-The following example shows how to create an advertisement by using the `SMS_Advertisement` class and class properties in System Center Configuration Manager.  
+The following example shows how to create an advertisement by using the [SMS_Advertisement] (../../../../reference/core/servers/configure/sms_advertisement-server-wmi-class.md) class and class properties in System Center Configuration Manager.  
 
 > [!IMPORTANT]
 >  To create an advertisement that targets a collection, you must have "Deploy Packages" permissions for the collection and "Read" permissions for the package.  


### PR DESCRIPTION
I created a link on SMS_Advertisement to link to the  url below.   SMS_Advertisement contains the info for advertisement flags.
https://github.com/MicrosoftDocs/SCCMdocs/blob/master/sccm/develop/reference/core/servers/configure/sms_advertisement-server-wmi-class.md

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)

@Article_Author please review (look at the `author` metadata tag)