### PR TITLE
M31959: Duplicate occurrence of "Active Directory"

### DIFF
--- a/sccm/core/clients/manage/cmg/cloud-management-gateway-faq.md
+++ b/sccm/core/clients/manage/cmg/cloud-management-gateway-faq.md
@@ -48,7 +48,7 @@ If your environment has more than one subscription, you can deploy CMG into any 
 
 This question is common in the following scenarios:  
 
-- When you have distinct test and production Active Directory and Azure AD environments, but one single, centralized Azure hosting subscription  
+- When you have distinct test and production Azure AD environments, but one single, centralized Azure hosting subscription  
 
 - Your use of Azure has grown organically across different teams  
 


### PR DESCRIPTION
Hello, @aczechowski,
Translator has reported possible source content issue. 
Description: Duplicate occurrence of "Active Directory"- As Active Directory and Azure AD are basically the same thing, we shortened the sentence. Maybe one term can be deleted from the source text.
Please review and merge the suggested proposed file change to avoid this error. If you make related fix in another PR, then share your PR number, so we can confirm and close this PR.
Many thanks in advance.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)

@Article_Author please review (look at the `author` metadata tag)