### PR TITLE
chore: Remove manual @ for PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,3 @@
 Describe your change, specifically *why* you think it's needed.
 
 Fixes #Issue_Number (if necessary)
-
-@Article_Author please review (look at the `author` metadata tag)


### PR DESCRIPTION
The PR bot is setup in the repo so this shouldn't be needed anymore