### PR TITLE
Fix broken "Accessibility Features" link.

### DIFF
--- a/sccm/core/servers/manage/admin-console.md
+++ b/sccm/core/servers/manage/admin-console.md
@@ -111,5 +111,5 @@ In Configuration Manager version 1806, the following console improvements are ad
 
 ## Next steps
 > [!div class="nextstepaction"]
-> [Accessibility Features](/sccm/core/understand/accessibility-features)
+> [Accessibility Features](../../understand/accessibility-features.md)
 

--- a/sccm/core/servers/manage/admin-console.md
+++ b/sccm/core/servers/manage/admin-console.md
@@ -111,5 +111,5 @@ In Configuration Manager version 1806, the following console improvements are ad
 
 ## Next steps
 > [!div class="nextstepaction"]
-> [Accessibility Features](/sccm/core/understand/accessibility-features.md)
+> [Accessibility Features](/sccm/core/understand/accessibility-features)
 


### PR DESCRIPTION
The link to the "Accessibility Features" page located at the bottom of the "Admin Console" page gives a 404 error. Drop .md extension to correct the broken link.