### PR TITLE
clarify definition of  Hybrid Azure AD

### DIFF
--- a/sccm/core/clients/manage/co-management-overview.md
+++ b/sccm/core/clients/manage/co-management-overview.md
@@ -65,9 +65,9 @@ Immediate use of the following Intune features:
 
 ### Azure Active Directory
 
- - Windows 10 devices must be joined or registered to Azure AD. This can be achieved through one of the following methods:  
+ - Windows 10 devices must be joined to Azure AD. They can be either of the following types:  
 
-     - [Hybrid Azure AD-joined](https://docs.microsoft.com/azure/active-directory/device-management-hybrid-azuread-joined-devices-setup), where the device is joined to your on-premises Windows Server AD domain while also registered with your Azure AD environment.
+     - [Hybrid Azure AD-joined](https://docs.microsoft.com/azure/active-directory/device-management-hybrid-azuread-joined-devices-setup), where the device is joined to your on-premises Active Directory and registered with your Azure Active Directory.
 
      - Azure AD-joined only. (This type is sometimes referred to as "cloud domain-joined")<!--SCCMDocs issue 605-->
 

--- a/sccm/core/clients/manage/co-management-overview.md
+++ b/sccm/core/clients/manage/co-management-overview.md
@@ -65,9 +65,9 @@ Immediate use of the following Intune features:
 
 ### Azure Active Directory
 
- - Windows 10 devices must be joined to Azure AD. They can be either of the following types:  
+ - Windows 10 devices must be joined or registered to Azure AD. This can be achieved through one of the following methods:  
 
-     - [Hybrid Azure AD-joined](https://docs.microsoft.com/azure/active-directory/device-management-hybrid-azuread-joined-devices-setup), where the device is joined to both Azure AD and your on-premises domain  
+     - [Hybrid Azure AD-joined](https://docs.microsoft.com/azure/active-directory/device-management-hybrid-azuread-joined-devices-setup), where the device is joined to your on-premises Windows Server AD domain while also registered with your Azure AD environment.
 
      - Azure AD-joined only. (This type is sometimes referred to as "cloud domain-joined")<!--SCCMDocs issue 605-->
 


### PR DESCRIPTION
I am proposing this change to clarify that Hybrid Azure Ad is where devices are "joined" to the on-premises WS AD domain, while registered to Azure AD, since devices cannot be both joined to WS AD-DS and Azure AD at the same time,  I believe the clarification puts this topic's "Hybrid Azure AD" definition in better alignment with the AzureAD  topic titled "What is device management in Azure Active Directory?" (https://docs.microsoft.com/en-us/azure/active-directory/devices/overview)

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
