### PR TITLE
Update co-management-prepare.md

### DIFF
--- a/sccm/core/clients/manage/co-management-prepare.md
+++ b/sccm/core/clients/manage/co-management-prepare.md
@@ -64,7 +64,7 @@ For more information about Azure roles, see [Understand the different roles](htt
 
 - Windows 10, version 1709 or later  
 
-- [Hybrid Azure AD-joined](https://docs.microsoft.com/azure/active-directory/device-management-hybrid-azuread-joined-devices-setup) (joined to AD and Azure AD) or Azure AD-joined only (this type is sometimes referred to as "cloud domain-joined").
+- [Hybrid Azure AD-joined](https://docs.microsoft.com/azure/active-directory/devices/hybrid-azuread-join-plan) (joined to AD and Azure AD) or Azure AD-joined only (this type is sometimes referred to as "cloud domain-joined").
 
 
 ### Additional prerequisites for devices without the Configuration Manager client


### PR DESCRIPTION
Updated the Hybrid Azure AD joined to get to the planning doc first.

### Summarize the change in the pull request title

Updating the link to the Hybrid Azure AD join plan document which decribes pre-requisites, how to control deployments and then follow up with an automated setup (recommended) or a manual process

Leading them to the manual changes for the final configuration leads to support cases and incidents due to mistakes in setup

Fixes #Issue_Number (if necessary)
Support Incident - Customers do not learn how to control their deployment first. 