### PR TITLE
Windows Autopilot for existing devices possible with 1809?

### DIFF
--- a/sccm/core/plan-design/changes/whats-new-in-version-1810.md
+++ b/sccm/core/plan-design/changes/whats-new-in-version-1810.md
@@ -223,7 +223,7 @@ A PowerShell profile is a script that runs when PowerShell starts. You can creat
 ### Task sequence support of Windows Autopilot for existing devices
 <!--1358333-->
 
-[Windows Autopilot for existing devices](https://techcommunity.microsoft.com/t5/Windows-IT-Pro-Blog/New-Windows-Autopilot-capabilities-and-expanded-partner-support/ba-p/260430), is now available with Windows 10 Insider Preview. This new feature allows you to reimage and provision a Windows 7 device for [Windows Autopilot user-driven mode](https://docs.microsoft.com/windows/deployment/windows-autopilot/user-driven) using a single, native Configuration Manager task sequence. 
+[Windows Autopilot for existing devices](https://techcommunity.microsoft.com/t5/Windows-IT-Pro-Blog/New-Windows-Autopilot-capabilities-and-expanded-partner-support/ba-p/260430), is now available with Windows 10, version 1809 or later. This new feature allows you to reimage and provision a Windows 7 device for [Windows Autopilot user-driven mode](https://docs.microsoft.com/windows/deployment/windows-autopilot/user-driven) using a single, native Configuration Manager task sequence. 
 
 <!--For more information, see []().--> 
 


### PR DESCRIPTION
1809 has been released so "Windows Autopilot for existing devices" no longer requires Insider Preview build?

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
