### PR TITLE
Update about Schedule re-evaluation for deployment

### DIFF
--- a/sccm/core/clients/deploy/about-client-settings.md
+++ b/sccm/core/clients/deploy/about-client-settings.md
@@ -620,7 +620,7 @@ For example, if your organization doesn't use compliance policies, and you want 
 Configure a schedule for when Configuration Manager reevaluates the requirement rules for all deployments. The default value is every seven days.  
 
 > [!IMPORTANT]  
->  Don't change this value to a lower value than the default. A more aggressive reevaluation schedule negatively affects the performance of your network and client computers.  
+>  This setting is much more invasive to the local client, than it is to the network or sitewerver. You could always set it faster, and carefully monitor the situation, and if it doesn’t work slow it back down.. A more aggressive reevaluation schedule negatively affects the performance of your network and client computers.  
 
 Initiate this action from a client as follows: in the **Configuration Manager** control panel, from the **Actions** tab, select **Application Deployment Evaluation Cycle**.  
 

--- a/sccm/core/clients/deploy/about-client-settings.md
+++ b/sccm/core/clients/deploy/about-client-settings.md
@@ -620,7 +620,7 @@ For example, if your organization doesn't use compliance policies, and you want 
 Configure a schedule for when Configuration Manager reevaluates the requirement rules for all deployments. The default value is every seven days.  
 
 > [!IMPORTANT]  
->  This setting is much more invasive to the local client, than it is to the network or sitewerver. You could always set it faster, and carefully monitor the situation, and if it doesn’t work slow it back down.. A more aggressive reevaluation schedule negatively affects the performance of your network and client computers.  
+> This setting is more invasive to the local client than it is to the network or site server. A more aggressive reevaluation schedule negatively affects the performance of your network and client computers. Microsoft doesn't recommend setting a lower value than the default. If you change this value, closely monitor performance.  
 
 Initiate this action from a client as follows: in the **Configuration Manager** control panel, from the **Actions** tab, select **Application Deployment Evaluation Cycle**.  
 


### PR DESCRIPTION
I asked this in Feb.2018 from Djam what is recommendation of Software deployment Schedule re-evaluation for deployments, he said "I think this setting is much more invasive to the local client, than it is to the network or sitewerver.   I do not like that global eval is 7 days.  That is far far too slow!   You could always set it faster, and carefully monitor the situation, and if it doesn’t work slow it back down.". 

I suggest our SCCM people change this schedule, but this document has to change first.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
