### PR TITLE
Update 1359029.md

### DIFF
--- a/sccm/core/get-started/includes/1810-2/1359029.md
+++ b/sccm/core/get-started/includes/1810-2/1359029.md
@@ -9,14 +9,14 @@ ms.date: 10/16/2018
 ## <a name="bkmk_msix"></a> Convert applications to MSIX
 <!--1359029-->
 
-Starting in version 1806, Configuration Manager supports deployment of the new Windows 10 app package (.msix) format. Now you can convert your existing Windows Installer (.msi) applications to the MSIX format. 
+Version 1806 of Configuration Manager supports deployment of the new Windows 10 app package (.msix) format. Starting with version 1810, you can convert your existing Windows Installer (.msi) applications to the MSIX format directly within the console. 
 
 For more information, see [Create Windows applications](/sccm/apps/get-started/creating-windows-applications#bkmk_general).
 
 
 ### Prerequisites
 
-- A reference device running Windows 10 version 17701 or later  
+- A reference device running Windows 10 version 1809 or later  
 
 - Sign in to Windows on this device as a user with local administrative rights  
 


### PR DESCRIPTION
Amended to reflect support for MSIX started in 1806, but in-console conversion started in 1810. Also felt that the version of Windows 10 required for the reference machine should match the version stated in the MSIX wizard that appears when converting, rather than an Insider release.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
