### PR TITLE
The ability to remove the Intune connection for existing on-premises …

### DIFF
--- a/sccm/core/plan-design/changes/whats-new-in-version-1810.md
+++ b/sccm/core/plan-design/changes/whats-new-in-version-1810.md
@@ -385,9 +385,9 @@ The SMS Provider now provides read-only API interoperability access to WMI over 
 
 ## <a name="bkmk_opmdm"></a> On-premises MDM
 
-### An Intune connection is no longer required for on-premises MDM
+### An Intune connection is no longer required for new on-premises MDM setups
 <!--1359124-->
-The on-premises MDM prerequisite to configure a Microsoft Intune subscription is no longer required. Your organization still requires Intune licenses to use this feature. 
+The on-premises MDM prerequisite to configure a Microsoft Intune subscription is no longer required for new setups. Your organization still requires Intune licenses to use this feature. The ability to remove the Intune connection, from existing on-premises MDM setups, deployed prior to the upgrade to ConfigMgr version 1810, is planned for a future a release. For more information, see the [Intune support blog post](https://techcommunity.microsoft.com/t5/Intune-Customer-Success/Move-from-Hybrid-Mobile-Device-Management-to-Intune-on-Azure/ba-p/280150).
 
 
 


### PR DESCRIPTION
…MDM customers is planned for a future a release.

I don’t think it is crystal clear that this only applies to new setups, though it says “to configure” – I think it would be reasonable to remove the connector in 1810, based on what we docd. Fixing the related issue requires contacting support.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
