### PR TITLE
Update prerequisites-for-software-updates.md

### DIFF
--- a/sccm/sum/plan-design/prerequisites-for-software-updates.md
+++ b/sccm/sum/plan-design/prerequisites-for-software-updates.md
@@ -27,7 +27,8 @@ This article lists the prerequisites for software updates in System Center Confi
 ### Windows Server Update Services  
  Windows Server Update Services (WSUS) is necessary for software updates synchronization and for the software updates applicability scan on clients. The WSUS server must be installed before you create the software update point role. The following versions of WSUS are supported for a software update point:  
 
--   WSUS 10.0 (role in Windows Server 2016)
+-   WSUS 10.0.14393 (role in Windows Server 2016)
+-   WSUS 10.0.17763 (role in Windows Server 2019) (Requires Configuration Manager 1810 or later)
 -   WSUS 6.2 and 6.3 (role in Windows Server 2012 and Windows Server 2012 R2)
 
 >[!NOTE]


### PR DESCRIPTION
core/plan-design/configs/supported-operating-systems-for-site-system-servers says a SUP is supported on 2019 as long as you're on 1810 or higher.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
