### PR TITLE
Update 'Common Failures' Statement

### DIFF
--- a/sccm/core/servers/manage/checklist-for-installing-update-1810.md
+++ b/sccm/core/servers/manage/checklist-for-installing-update-1810.md
@@ -27,7 +27,7 @@ To get the update for version 1810, you must use a service connection point at t
 
     -   The dmpdownloader.log may indicate that the dmpdownloader process is waiting for an interval before checking for updates. To restart the download of the update's redistribution files, restart the **SMS_Executive** service on the site server.
 
-    -   Another common download issue occurs when proxy server settings prevent downloads from http://silverlight.dlservice.microsoft.com and http://download.microsoft.com.
+    -   Another common download issue occurs when proxy server settings prevent downloads from http://silverlight.dlservice.microsoft.com, http://download.microsoft.com, and/or http://go.microsoft.com.
 
 For more information about installing updates, see [In-console updates and servicing](/sccm/core/servers/manage/updates#a-namebkmkinconsolea-in-console-updates-and-servicing).
 


### PR DESCRIPTION
@aczechowski 
Confirmed on a current support ticket that the SCCM 1810 upgrade can fail if the SCCM server does not have access to http://go.microsoft.com.

Failed to download redist for 454b3508-4387-4106-9441-283495dec3ec with command  /RedistUrl http://go.microsoft.com/fwlink/?LinkID=855648 /LnManifestUrl http://go.microsoft.com/fwlink/?LinkID=855631

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

I added blocked access to "http://go.microsoft.com" as a potential cause of failure for downloading the 1810 SCCM upgrade.