### PR TITLE
Update endpoint-definitions-configmgr.md

### DIFF
--- a/sccm/protect/deploy-use/endpoint-definitions-configmgr.md
+++ b/sccm/protect/deploy-use/endpoint-definitions-configmgr.md
@@ -44,10 +44,10 @@ ms.collection: M365-identity-device-management
 
 6. Make sure that the  **Enable the deployment after this rule is run** check box is selected, and then click **Next**.
 
-7. On the **Deployment Settings** page of the wizard, in the **Detail level** list, select **Minimal**, and then click **Next**.
+7. On the **Deployment Settings** page of the wizard, in the **Detail level** list, select **Only error messages**, and then click **Next**.
 
    > [!NOTE]
-   >  From the **Detail level** list, select **Minimal** (Configuration Manager with no Service Pack) or **Only error messages** (Configuration Manager). This will reduce the number of state messages returned by definition deployment. This configuration helps reduce the CPU processing usage on the Configuration Manager servers.
+   >  Selecting **Only error messages** will reduce the number of state messages returned by definition deployment. This configuration helps reduce the CPU processing usage on the Configuration Manager servers.
 
 8. In the **Property filters** list, select the **Update Classification** check box.
 


### PR DESCRIPTION
Removed references to "Service Pack" and options ("Minimal") that do not exist in Configuration Manager current branch.