### PR TITLE
More specific about CMG supported task sequences

### DIFF
--- a/sccm/core/clients/manage/cmg/plan-cloud-management-gateway.md
+++ b/sccm/core/clients/manage/cmg/plan-cloud-management-gateway.md
@@ -206,7 +206,8 @@ The following table lists CMG support for Configuration Manager features:
 | Software distribution (device-targeted)     | ![Supported](media/green_check.png) |
 | Software distribution (user-targeted, required)<br>(with Azure AD integration)     | ![Supported](media/green_check.png)  (1710) |
 | Software distribution (user-targeted, available)<br>([all requirements](/sccm/apps/deploy-use/deploy-applications#deploy-user-available-applications-on-azure-ad-joined-devices)) | ![Supported](media/green_check.png)  (1802) |
-| Windows 10 in-place upgrade task sequence     | ![Supported](media/green_check.png)  (1802) |
+| Windows 10 in-place upgrade task sequence      | ![Supported](media/green_check.png)  (1802) |
+| Task sequences which are not using boot images and are deployed with an option: **Download all content locally before starting task sequence**      | ![Supported](media/green_check.png)  (1802) |
 | CMPivot     | ![Supported](media/green_check.png)  (1806) |
 | Any other task sequence scenario     | ![Not supported](media/Red_X.png) |
 | Client push     | ![Not supported](media/Red_X.png) |


### PR DESCRIPTION
You can run from CMG TSes which don't use WinPE and are deployed with an option: "download all content before starting ts"

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
