### PR TITLE
Updated DPMP

### DIFF
--- a/sccm/core/get-started/azure-template.md
+++ b/sccm/core/get-started/azure-template.md
@@ -111,10 +111,10 @@ Active Directory domain controller
 - Internet Information Service (IIS)
 
 
-### `<prefix>MPDP`
+### `<prefix>DPMP`
 
-- Management point
 - Distribution point
+- Management point
 
 #### Windows features and roles
 - .NET


### PR DESCRIPTION
DPMP had "MPDP" as the hostname suffix, which is incorrect.  Also, re-ordered the roles to be alphabetical for DPMP

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
