### PR TITLE
Update certificates-for-cloud-management-gateway.md

### DIFF
--- a/sccm/core/clients/manage/cmg/certificates-for-cloud-management-gateway.md
+++ b/sccm/core/clients/manage/cmg/certificates-for-cloud-management-gateway.md
@@ -38,7 +38,7 @@ For more information about the different scenarios, see [plan for cloud manageme
 <!--SCCMDocs issue #779-->
 Certificates for the cloud management gateway support the following configurations:  
 
-- **4096-bit key length**  
+- 2048 or 4096-bit key length
 
 - Starting in version 1710, support for key storage providers for certificate private keys. For more information, see [CNG certificates overview](/sccm/core/plan-design/network/cng-certificates-overview).  
 

--- a/sccm/core/clients/manage/cmg/certificates-for-cloud-management-gateway.md
+++ b/sccm/core/clients/manage/cmg/certificates-for-cloud-management-gateway.md
@@ -38,7 +38,7 @@ For more information about the different scenarios, see [plan for cloud manageme
 <!--SCCMDocs issue #779-->
 Certificates for the cloud management gateway support the following configurations:  
 
-- 2048 or 4096-bit key length
+- 2048- or 4096-bit key length
 
 - Starting in version 1710, support for key storage providers for certificate private keys. For more information, see [CNG certificates overview](/sccm/core/plan-design/network/cng-certificates-overview).  
 


### PR DESCRIPTION
2048 bit key lenth is also supported. This was confusing because it sounded like you must use 4096. Also not sure why it was in bold.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
