### PR TITLE
Update use-a-sql-server-cluster-for-the-site-database.md

### DIFF
--- a/sccm/core/servers/deploy/configure/use-a-sql-server-cluster-for-the-site-database.md
+++ b/sccm/core/servers/deploy/configure/use-a-sql-server-cluster-for-the-site-database.md
@@ -17,7 +17,7 @@ ms.collection: M365-identity-device-management
 
 *Applies to: System Center Configuration Manager (Current Branch)*
 
-You can use a SQL Server cluster to host the Configuration Manager site database. A cluster provides failover support and improves the reliability of the site database. However, it doesn't provide additional processing or load-balancing benefits. Degradation in performance can occur, because the site server must find the active node of the SQL Server cluster before it connects to the site database.  
+You can use a SQL Server Failover cluster to host the Configuration Manager site database. A cluster provides failover support and improves the reliability of the site database. However, it doesn't provide additional processing or load-balancing benefits. Additionally, a SQL Server Failover cluster uses shared storage and introduces a single point of failure. Degradation in performance can occur, because the site server must find the active node of the SQL Server cluster before it connects to the site database.  
 
 > [!IMPORTANT]  
 > Successful set up of SQL Server clusters relies on documentation and procedures provided in the SQL Server documentation library.  


### PR DESCRIPTION
###  FCI, shared storage introduces a single point of failure

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
To clearly state one of the issue with SQL and FCI, shared storage introduces a single point of failure. This same limitation does not exist with SQL AlwaysOn Availability Groups.
-Steve