### PR TITLE
Exclude contents under includes folder

### DIFF
--- a/sccm/docfx.json
+++ b/sccm/docfx.json
@@ -8,6 +8,7 @@
         ],
         "exclude": [
           "**/obj/**",
+          "**/includes/**",
           "sccm/**"
         ]
       }


### PR DESCRIPTION
Contents inside `includes` folder are tokens, they can skip build and publish. This PR adds them to the content exclusion list to speed up build time and reduce output size.