### PR TITLE
Note WSUS Admin Console required on site server when SUP isn't installed local in design doc

### DIFF
--- a/sccm/core/plan-design/configs/site-and-site-system-prerequisites.md
+++ b/sccm/core/plan-design/configs/site-and-site-system-prerequisites.md
@@ -511,7 +511,8 @@ The default IIS configuration is required.
 
 -   For more information, see [Plan for software updates](/sccm/sum/plan-design/plan-for-software-updates).  
 
-
+> [!NOTE]  
+> When you use a Software Update Point on a server other than the site server, you must install the WSUS Administration Console on the site server.   
 
 ##  <a name="bkmk_2012SMPpreq"></a> State migration point  
 <!--SCCMDocs issue 645-->


### PR DESCRIPTION
### Summarize the change in the pull request title

Added note that when SUP on any server other than site server, WSUS Admin Console must be installed on site server. This is covered in the prerequisite documentation but not in the design doc.  

Fixes #1409  (if necessary)
