### PR TITLE
Fixed Logging Path

### DIFF
--- a/sccm/sum/tools/updates-publisher-options.md
+++ b/sccm/sum/tools/updates-publisher-options.md
@@ -117,7 +117,7 @@ to open the **Updates Publisher Properties**, and then choose **Check for update
 After Updates Publisher finds a new update, it displays the **Update Available** window and you can then choose to install it. If you choose to not install the update, it is offered the next time you open the console.
 
 ## Logging
-Updates Publisher logs basic information about Updates Publisher to **&lt;*path*&gt;\Windows\Temp\UpdatesPublisher.log**.
+Updates Publisher logs basic information about Updates Publisher to **%WINDIR%\Temp\UpdatesPublisher.log**.
 
 Use notepad or **CMTrace** to view the log. CMTrace is the Configuration Manager log file tool and can be found in the **\SMSSetup\Tools** folder of the Configuration Manager source media.
 


### PR DESCRIPTION
Removed reference to <path> which seemed to really be indicating the system drive, and replace with proper reference to %WINDIR%.

Submission for #MMS2019Docathon