### PR TITLE
Add Popular Non-Microsoft Links to Community

### DIFF
--- a/sccm/index.md
+++ b/sccm/index.md
@@ -993,7 +993,7 @@ ms.collection: M365-identity-device-management
                                             </div>
                                             <div class="cardText">
                                                 <h3>#ConfigMgr on Twitter</h3>
-                                                <p>Read the latest tweets about Configuration Manager. </p>
+                                                <p>Read the latest tweets about Configuration Manager.�</p>
                                             </div>
                                         </div>
                                     </div>
@@ -1069,13 +1069,51 @@ ms.collection: M365-identity-device-management
                                             </div>
                                             <div class="cardText">
                                                 <h3>Enterprise Mobility + Security blog</h3>
-                                                <p>The latest news about unified endpoint management.</p>
+                                                <p>The latest news�about unified endpoint management.</p>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                                 </a>
                             </li>                            
+                            <li>
+                                <a href="https://slofile.com/slack/winadmins">
+                                <div class="cardSize">
+                                    <div class="cardPadding">
+                                        <div class="card">
+                                            <div class="cardImageOuter">
+                                                <div class="cardImage">
+                                                    <img src="https://upload.wikimedia.org/wikipedia/commons/7/76/Slack_Icon.png" alt="" />
+                                                </div>
+                                            </div>
+                                            <div class="cardText">
+                                                <h3>WinAdmins Slack</h3>
+                                                <p>Community of System Administrators collaborating in real time.</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="https://www.reddit.com/r/sccm">
+                                <div class="cardSize">
+                                    <div class="cardPadding">
+                                        <div class="card">
+                                            <div class="cardImageOuter">
+                                                <div class="cardImage">
+                                                    <img src="https://upload.wikimedia.org/wikipedia/commons/e/e5/Reddit_logo_orange.svg" alt="" />
+                                                </div>
+                                            </div>
+                                            <div class="cardText">
+                                                <h3>SCCM Subreddit</h3>
+                                                <p>A subreddit for the discussion of SCCM.</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                </a>
+                            </li>
                         </ul>
                     </li>
                 </ul>


### PR DESCRIPTION
Adding the Slack channel and /r/SCCM from Reddit to the community links page.  Using images as hotlinks (permitted by WikiCommons), however, if published, a docs administrator may want to consider setting up a media folder as contributors do not have access to the media folder at the root of docs.microsoft.com that other images are using.

There is a precedent for linking out to non-Microsoft communities from docs, such as with 
https://docs.microsoft.com/en-us/sql/sql-server/sql-server-2016-release-notes and https://docs.microsoft.com/en-us/power-bi/developer/azure-pbie-what-is-power-bi-embedded.

In addition, removed two non-standard characters that were in the document but were not required.

#MMS2019Docathon
