### PR TITLE
Update calling-code-snippets.md

### DIFF
--- a/sccm/develop/core/understand/calling-code-snippets.md
+++ b/sccm/develop/core/understand/calling-code-snippets.md
@@ -14,10 +14,7 @@ ms.collection: M365-identity-device-management
 # Calling Configuration Manager Code Snippets
 The following code samples show how to set up the calling code for the code examples that are used throughout the System Center Configuration Manager Software Development Kit (SDK).  
 
- Replace the SNIPPETMETHOD snippet with the snippet that you want to run. In most cases you will need to make changes, such as adding parameters, to make the code work.  
-
-> [!NOTE]
->  The ScriptPW COM automation object is not available in Windows Vista. If you do not want to pass your password in clear text, an alternative is to use a HTML application. For more information, see [Creating Your Own HTAs](http://go.microsoft.com/fwlink/?LinkId=110367).  
+ Replace the SNIPPETMETHOD snippet with the snippet that you want to run. In most cases you will need to make changes, such as adding parameters, to make the code work.   
 
  For more information about remote Windows Management Instrumentation (WMI) connections, see [Connecting to WMI on a Remote Computer](http://go.microsoft.com/fwlink/?LinkId=94683).  
 


### PR DESCRIPTION
Removed link referencing HTA's in Windows Vista Fixes #1466

#MMS2019Docathon

### Summarize the change in the pull request title

Removed link referencing HTA's in Windows Vista Fixes #1466 

Fixes #1466 
