### PR TITLE
Update CmPivot.md - Starting with 1902

### DIFF
--- a/sccm/core/servers/manage/cmpivot.md
+++ b/sccm/core/servers/manage/cmpivot.md
@@ -385,10 +385,10 @@ Running CMPivot on the CAS will require additional permissions when SQL or the p
 
 To get CMPivot to work on the CAS in such a “double hop scenario”, you can define constrained delegation. To understand the security implications of this configuration, read the [Kerberos constrained delegation](https://docs.microsoft.com/windows-server/security/kerberos/kerberos-constrained-delegation-overview) article. If you have more than one remote configuration such as SQL or SCCM Provider being colocated with the CAS or not, you may require a combination of permission settings. Below are the steps that you need to take:
 
-> [!Note]  
-> If other web service automation, third party solutions or similar auomation leverages kerberos authentication to perform database lookups you will need to register additional SPNs for those web services or automation. Those SPNs will need to be added to the constrained delegation tab for the relavent database account.
--Example of creating a SPN for a webservice. -HTTP switch works for HTTPS and HTTP sites.
--Example Setspn -A HTTP/SCCMAUTOMATION.CONTOSO.LOCAL CONTOSO\SCCMAUTOMATION 
+> [!Note]
+> In the event custom web services, third party solutions or similar automation exist in your environment and NTLM Fallback is not allowed, you will need to register additional SPNs for those web services and/or other automation. Add the new SPNs to the constrained delegation tab for the relevant database account. Even if NTLM Fallback is allowed and the services continue to function, SPNs may still need to be added if NTLM authentication is not desired.
+> -Example of creating a SPN for a web service.
+> Setspn -A HTTP/SCCMAUTOMATION.CONTOSO.COM CONTOSO\SCCMAUTOMATION
 
 ### CAS has a remote SQL server
 

--- a/sccm/core/servers/manage/cmpivot.md
+++ b/sccm/core/servers/manage/cmpivot.md
@@ -385,6 +385,11 @@ Running CMPivot on the CAS will require additional permissions when SQL or the p
 
 To get CMPivot to work on the CAS in such a “double hop scenario”, you can define constrained delegation. To understand the security implications of this configuration, read the [Kerberos constrained delegation](https://docs.microsoft.com/windows-server/security/kerberos/kerberos-constrained-delegation-overview) article. If you have more than one remote configuration such as SQL or SCCM Provider being colocated with the CAS or not, you may require a combination of permission settings. Below are the steps that you need to take:
 
+> [!Note]  
+> If other web service automation, third party solutions or similar auomation leverages kerberos authentication to perform database lookups you will need to register additional SPNs for those web services or automation. Those SPNs will need to be added to the constrained delegation tab for the relavent database account.
+-Example of creating a SPN for a webservice. -HTTP switch works for HTTPS and HTTP sites.
+-Example Setspn -A HTTP/SCCMAUTOMATION.CONTOSO.LOCAL CONTOSO\SCCMAUTOMATION 
+
 ### CAS has a remote SQL server
 
 1. Go to each primary site's SQL server.

--- a/sccm/core/servers/manage/cmpivot.md
+++ b/sccm/core/servers/manage/cmpivot.md
@@ -385,7 +385,7 @@ Running CMPivot on the CAS will require additional permissions when SQL or the p
 
 To get CMPivot to work on the CAS in such a “double hop scenario”, you can define constrained delegation. To understand the security implications of this configuration, read the [Kerberos constrained delegation](https://docs.microsoft.com/windows-server/security/kerberos/kerberos-constrained-delegation-overview) article. If you have more than one remote configuration such as SQL or SCCM Provider being colocated with the CAS or not, you may require a combination of permission settings. Below are the steps that you need to take:
 
-> [!Note]
+> [!NOTE]
 > In the event custom web services, third party solutions or similar automation exist in your environment and NTLM Fallback is not allowed, you will need to register additional SPNs for those web services and/or other automation. Add the new SPNs to the constrained delegation tab for the relevant database account. Even if NTLM Fallback is allowed and the services continue to function, SPNs may still need to be added if NTLM authentication is not desired.
 > -Example of creating a SPN for a web service.
 > Setspn -A HTTP/SCCMAUTOMATION.CONTOSO.COM CONTOSO\SCCMAUTOMATION


### PR DESCRIPTION
Constrained Delegation will deny any other Kerberos request not listed in the list of allowed services for delegation. This can have unintended consequences where other Web Services, third party plugins or potential ACPs will break when constrained delegation is configured. I am suggesting a Note that additional SPNs and delegation will be needed for those solutions.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
