### PR TITLE
Add important note regarding "Run from DP" option

### DIFF
--- a/sccm/osd/understand/task-sequence-steps.md
+++ b/sccm/osd/understand/task-sequence-steps.md
@@ -285,7 +285,7 @@ Configure the task sequence to access the OS image directly from the distributio
 > This setting overrides the deployment option that you configure on the **Distribution Points** page in the **Deploy Software Wizard**. This override is only for the OS image that this step specifies, not for all task sequence content.  
 
 > [!IMPORTANT]  
-> For greatest security it is strongly recommended not to select this option. This option is mainly designed for use on devices with limited storage capacity. This option is not meant to help increase the speed of the Task Sequence. When this option is selected the package hash is not verified for the operating system package. Therefore, package integrity cannot be ensured as it is possible for users with administrative rights to alter or tamper with package contents.
+> For greatest security, it is strongly recommended not to select this option. This option is mainly designed for use on devices with limited storage capacity. This option is not meant to help increase the speed of the task sequence. When this option is selected, the package hash is not verified for the operating system package. Therefore, package integrity cannot be ensured because it is possible for users with administrative rights to alter or tamper with package contents.
 
 
 

--- a/sccm/osd/understand/task-sequence-steps.md
+++ b/sccm/osd/understand/task-sequence-steps.md
@@ -284,6 +284,9 @@ Configure the task sequence to access the OS image directly from the distributio
 > [!NOTE]  
 > This setting overrides the deployment option that you configure on the **Distribution Points** page in the **Deploy Software Wizard**. This override is only for the OS image that this step specifies, not for all task sequence content.  
 
+> [!IMPORTANT]  
+> For greatest security it is strongly recommended not to select this option. This option is mainly designed for use on devices with limited storage capacity. This option is not meant to help increase the speed of the Task Sequence. When this option is selected the package hash is not verified for the operating system package. Therefore, package integrity cannot be ensured as it is possible for users with administrative rights to alter or tamper with package contents.
+
 
 
 ## <a name="BKMK_ApplyWindowsSettings"></a> Apply Windows Settings  


### PR DESCRIPTION
Add important note regarding Access content directly from the distribution point option. CM 07 docs contained warnings about "Run from DPs" options regarding package hashes not being checked. These docs did not make it over to CM CB docs, especially with this option that was introduced in CM 12.
