### PR TITLE
Remove "Configure auto-enrollment of devices to Intune"

### DIFF
--- a/sccm/comanage/tutorial-co-manage-clients.md
+++ b/sccm/comanage/tutorial-co-manage-clients.md
@@ -120,30 +120,6 @@ Use Client Settings to configure Configuration Manager clients to automatically 
 
 4. Select **OK** to save this configuration.  
 
-## Configure auto-enrollment of devices to Intune   
-Next, we’ll set up auto-enrollment of devices with Intune. With automatic enrollment, devices you manage with Configuration Manager automatically enroll with Intune.
-
-Automatic enrollment also lets users enroll their Windows 10 devices to Intune. Devices enroll when a user adds their work account to their personally owned device, or when a corporate-owned device is joined to Azure Active Directory.  
-
-1. Sign in to the [Azure portal](https://portal.azure.com/) and select **Azure Active Directory** > **Mobility (MDM and MAM)** > **Microsoft Intune**.  
-
-2. Configure **MDM user scope**. Specify one of the following to configure which users’ devices are managed by Microsoft Intune and accept the defaults for the URL values.  
-
-   - **Some** - Select the **Groups** that can automatically enroll their Windows 10 devices  
-
-   - **All** - All users can automatically enroll their Windows 10 devices
-when set to **None**, Mobile Device Management (MDM) automatic enrollment is disabled
-
-   > [!IMPORTANT]  
-   > If both **MAM user scope** and automatic MDM enrollment (**MDM user scope**) are enabled for a group, only MAM is enabled. Only Mobile Application Management (MAM) is added for users in that group when they workplace join personal device. Devices are not automatically MDM  enrolled.  
-
-3. Select **Save** to complete configuration of automatic enrollment.  
-
-4. Return to **Mobility (MDM and MAM)** and then select **Microsoft Intune Enrollment**.  
-
-5. For MDM user scope, select **All**, and then **Save**.  
-
-
 ## Assign Intune licenses to users   
 A commonly overlooked but critical action is to assign an Intune license to each user who will use a device that is co-managed.  
 


### PR DESCRIPTION
Section "Configure auto-enrollment of devices to Intune" is not required for co-management, because related to direct Windows PCs enrollment to Intune (Autopilot or Intune-only managed).

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
