### PR TITLE
Added local admin account requirement for the Run PowerShell Script task

### DIFF
--- a/sccm/osd/understand/task-sequence-steps.md
+++ b/sccm/osd/understand/task-sequence-steps.md
@@ -1618,7 +1618,7 @@ Starting in version 1902, specify that the PowerShell script is run as a Windows
 #### Account
 
 <!-- 3556028 -->
-Starting in version 1902, specify the Windows user account this step uses to run the PowerShell script. The script runs with the permissions of the specified account. Select **Set** to specify the local user or domain account. For more information on the task sequence run-as account, see [Accounts](/sccm/core/plan-design/hierarchy/accounts#task-sequence-run-as-account).
+Starting in version 1902, specify the Windows user account this step uses to run the PowerShell script. The specified account must be a local administrator on the system and the script runs with the permissions of this account. Select **Set** to specify the local user or domain account. For more information on the task sequence run-as account, see [Accounts](/sccm/core/plan-design/hierarchy/accounts#task-sequence-run-as-account).
 
 > [!IMPORTANT]  
 > If this step specifies a user account and runs in Windows PE, the action fails. You can't join Windows PE to a domain. The **smsts.log** file records this failure.  


### PR DESCRIPTION
Added local admin account requirement for the Run PowerShell Script task per the comments at https://www.reddit.com/r/SCCM/comments/c8parf/running_powershell_script_during_ts_failing/ by /u/vsoro00 (who I'm assuming is Vlad Sorokin).
