### PR TITLE
Fixed link title

### DIFF
--- a/sccm/desktop-analytics/overview.md
+++ b/sccm/desktop-analytics/overview.md
@@ -115,4 +115,4 @@ Desktop Analytics requires one of the following license subscriptions:
 
 The following tutorial provides a step-by-step guide to getting started with Desktop Analytics and Configuration Manager:  
 
-- [Deploy Windows 10 to a pilot](/sccm/desktop-analytics/tutorial-windows10)  
+- [Deploy Windows 10 to pilot](/sccm/desktop-analytics/tutorial-windows10)  


### PR DESCRIPTION
The title of the page linked to is “to pilot” not “to a pilot”. Changed link to match.

