### PR TITLE
Update plan-cloud-management-gateway.md

### DIFF
--- a/sccm/core/clients/manage/cmg/plan-cloud-management-gateway.md
+++ b/sccm/core/clients/manage/cmg/plan-cloud-management-gateway.md
@@ -18,7 +18,7 @@ ms.collection: M365-identity-device-management
 *Applies to: System Center Configuration Manager (Current Branch)*
 
 <!--1101764-->
-The cloud management gateway (CMG) provides a simple way to manage Configuration Manager clients on the internet. By deploying the CMG as a cloud service in Microsoft Azure, you can manage traditional clients that roam on the internet without additional infrastructure. You also don't need to expose your on-premises infrastructure to the internet.
+The cloud management gateway (CMG) provides a simple way to manage Configuration Manager clients on the internet. By deploying the CMG as a cloud service in Microsoft Azure, you can manage traditional clients that roam on the internet without additional on-premises infrastructure. You also don't need to expose your on-premises infrastructure to the internet.
 
 > [!Note]  
 > Configuration Manager doesn't enable this optional feature by default. You must enable this feature before using it. For more information, see [Enable optional features from updates](/sccm/core/servers/manage/install-in-console-updates#bkmk_options).<!--505213-->  


### PR DESCRIPTION
added "on-premises" to "...without additional infrastructure." Azure VM Infrastructure (even though it is mostly considered a PaaS service) could be considered additional infrastructure to the CM environment as a whole.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
