### PR TITLE
Improve the Metering section

### DIFF
--- a/sccm/core/plan-design/hierarchy/log-files.md
+++ b/sccm/core/plan-design/hierarchy/log-files.md
@@ -640,7 +640,9 @@ The following table lists the log files that contain information related to Disc
 
 |Log name|Description|Computer with log file|  
 |--------------|-----------------|----------------------------|  
-|mtrmgr.log|Monitors all software metering processes.|Site server|  
+|mtrmgr.log|Monitors all software metering processes.|Client|  
+|SWMTRReportGen.log|Generates a use data report that is collected by the metering agent. This data is logged in Mtrmgr.log.|Client|
+|swmproc.log|Records the processing of metering files and settings.|Site server|
 
 ###  <a name="BKMK_MigrationLog"></a> Migration  
  The following table lists the log files that contain information related to migration.  


### PR DESCRIPTION
mtrmgr.log was listed to being on a site server but it's on the client. It's worth pointing out I see mtrmgr.log in the MP logs folder too.

I feel the section's intention is to list all logs that are relevant to metering to hopefully this PR improves that by including SWMTRReportGen.log and swmproc.log in the list too.