### PR TITLE
Remove Driver Inventory from Assets section

### DIFF
--- a/sccm/desktop-analytics/about-assets.md
+++ b/sccm/desktop-analytics/about-assets.md
@@ -20,8 +20,7 @@ ms.collection: M365-identity-device-management
 
 After devices report data to Desktop Analytics, it provides an inventory of the following assets:
 
-- Devices  
-- Hardware drivers  
+- Devices
 - Installed apps  
 
 In the service portal, select **Assets** in the Desktop Analytics menu.


### PR DESCRIPTION
DA only has Driver Inventory for Known Issues.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
