### PR TITLE
Removed Extra "to" in the warning about parameters

### DIFF
--- a/sccm/apps/deploy-use/create-deploy-scripts.md
+++ b/sccm/apps/deploy-use/create-deploy-scripts.md
@@ -62,7 +62,7 @@ Run Scripts currently supports:
 
 
 >[!WARNING]
->Be aware that when using parameters, it opens a surface area for potential PowerShell injection attack risk. There are various ways to mitigate and work around, such as using regular expressions to validate parameter input or using predefined parameters. Common best practice is not to include to secrets in your PowerShell scripts (no passwords, etc.). [Learn more about PowerShell script security](/sccm/apps/deploy-use/learn-script-security) <!--There are external tools available to validate your PowerShell scripts such as the [PowerShell Injection Hunter](https://www.powershellgallery.com/packages/InjectionHunter/1.0.0) tool. -->
+>Be aware that when using parameters, it opens a surface area for potential PowerShell injection attack risk. There are various ways to mitigate and work around, such as using regular expressions to validate parameter input or using predefined parameters. Common best practice is not to include secrets in your PowerShell scripts (no passwords, etc.). [Learn more about PowerShell script security](/sccm/apps/deploy-use/learn-script-security) <!--There are external tools available to validate your PowerShell scripts such as the [PowerShell Injection Hunter](https://www.powershellgallery.com/packages/InjectionHunter/1.0.0) tool. -->
 
 
 ## Run Script authors and approvers


### PR DESCRIPTION
There was an extra usage of the word "to" in the !Warning around using Parameters.

### Summarize the change in the pull request title

Extra word in sentence "is not to include to secrets" 

Removed extra word. 

Fixes #Issue_Number (if necessary)
