### PR TITLE
A couple of modifications to a collection to AAD group sync

### DIFF
--- a/sccm/core/clients/manage/collections/create-collections.md
+++ b/sccm/core/clients/manage/collections/create-collections.md
@@ -232,7 +232,8 @@ The Azure AD synchronization happens every five minutes. It's a one-way process,
 
 1. Go to [https://portal.azure.com](https://portal.azure.com).
 1. Navigate to **Azure Active Directory** > **Groups** > **All groups**.
-1. Click **New group** and type in a **Group name** and **Group description**.
+1. Click **New group** and type in a **Group name** and optionally **Group description**.
+1. Make sure that **Membership type** is **Assigned**.
 1. Select **Owners**, then add the identity that will create the synchronization relationship in Configuration Manager.
 1. Click **Create** to finish creating the Azure AD group.
 


### PR DESCRIPTION
When you want to use a collection to AAD group sync feature, the target group doesn't need to have a description, but you need to make sure that the membership type = Assigned. Dynamic device/user groups don't work.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
