### PR TITLE
Changed a typo from "hours" where UI is in "minutes"

### DIFF
--- a/sccm/core/clients/deploy/about-client-settings.md
+++ b/sccm/core/clients/deploy/about-client-settings.md
@@ -320,8 +320,8 @@ The following settings must be shorter in duration than the shortest maintenance
 
 For more information about maintenance windows, see [How to use maintenance windows](/sccm/core/clients/manage/collections/use-maintenance-windows).
 
-- **Specify the snooze duration for computer restart countdown notifications (hours)** (Starting in version 1906)<!--3976435-->
-  - The default value is 4 hours.
+- **Specify the snooze duration for computer restart countdown notifications (minutes)** (Starting in version 1906)<!--3976435-->
+  - The default value is 240 minutes.
   - Your snooze duration value should be less than the temporary notification value minus the value for the notification the user cant dismiss.
   - For more information, see [Device restart notifications](/sccm/core/clients/deploy/device-restart-notifications).
 


### PR DESCRIPTION
As per Aarons note from #1824  I have amended the "Specify the snooze duration for computer restart countdown notifications" client setting from hours to minutes to reflect the UI. Also changed default value from 4 hours to 240 minutes to also reflect the UI value.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
