### PR TITLE
Updated Start CMPivot Permissions for new "Run CMPivot" permission available in 1906 and higher

### DIFF
--- a/sccm/core/clients/manage/client-notification.md
+++ b/sccm/core/clients/manage/client-notification.md
@@ -65,6 +65,7 @@ Starts **CMPivot**, which runs real-time queries against the targeted devices. F
 #### Permissions
 This action requires the same permissions as the [Run script](#run-script) action. 
 
+Starting in version 1906, you can use the **Run CMPivot** permission on the **Collection** object.
 
 
 ## Client notification


### PR DESCRIPTION
Updated Start CMPivot permissions required to use the "Run CMPivot" permission that is new to 1906. 

Reference https://docs.microsoft.com/en-us/sccm/core/servers/manage/cmpivot#prerequisites

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
