### PR TITLE
Incorrect Windows Insider CUs Info

### DIFF
--- a/sccm/sum/get-started/configure-classifications-and-products.md
+++ b/sccm/sum/get-started/configure-classifications-and-products.md
@@ -81,7 +81,7 @@ For more information about support for Windows Insider in Configuration Manager,
 
 ### Enable Windows Insider upgrades and updates
 
-You need to enable the products and classifications for Windows Insider upgrades and updates. Feature Updates for Windows Insider are under the **Windows Insider Pre-Release** product. However, Cumulative Updates and other updates for Windows Insider will be under the product **Windows 10, version 1903 and later**.
+You need to enable the products and classifications for Windows Insider upgrades and updates. Feature Updates, Cumulative updates, and other updates for Windows Insider are under the **Windows Insider Pre-Release** product category.
 
 1. In the **Configuration Manager** console, navigate to **Administration** > **Site Configuration** > **Sites**.
 2. Select the central administration site or the stand-alone primary site.  
@@ -115,7 +115,7 @@ For more information on how to deploy upgrades, see [Manage Windows as a service
 
 ### Keeping Insider devices up-to date
 
-Cumulative Updates for Windows Insider will be available for WSUS and by extension for Configuration Manager. These Cumulative Updates will be released at a frequency similar to Windows 10 version 1903 Cumulative Updates. The Windows Insider Cumulative updates are in the **Windows 10, version 1903 and later** product category and classified as either **Security Updates** or **Updates**. You can deploy the Cumulative Updates for Windows Insider using your regular software update process like using [automatic deployment rules](/sccm/sum/deploy-use/automatically-deploy-software-updates) or [phased deployments](/sccm/osd/deploy-use/create-phased-deployment-for-task-sequence?toc=/sccm/sum/toc.json&bc=/sccm/sum/breadcrumb/toc.json).
+Cumulative Updates for Windows Insider will be available for WSUS and by extension for Configuration Manager. These Cumulative Updates will be released at a frequency similar to Windows 10 version 1903 Cumulative Updates. The Windows Insider Cumulative updates are in the **Windows Insider Pre-Release** product category and classified as either **Security Updates** or **Updates**. You can deploy the Cumulative Updates for Windows Insider using your regular software update process like using [automatic deployment rules](/sccm/sum/deploy-use/automatically-deploy-software-updates) or [phased deployments](/sccm/osd/deploy-use/create-phased-deployment-for-task-sequence?toc=/sccm/sum/toc.json&bc=/sccm/sum/breadcrumb/toc.json).
 
 ## <a name="bkmk_ESU"></a> Extended Security Updates and Configuration Manager
 


### PR DESCRIPTION
The doc incorrectly state that updates for Windows Insider builds will be released under the 'Windows 10 1903 and later' category.  As of October 2019 and Windows 10 1909 this is not true.  I just did a sync and found no Insider Updates in the 'Windows 10 1903 and later' product category. I added the 'Windows Insider Pre-Release' product category, synced updates, and CUs and SSUs for 1909 appeared under that category.