### PR TITLE
More possible values for OfferFlags property

### DIFF
--- a/sccm/develop/reference/apps/sms_applicationassignment-server-wmi-class.md
+++ b/sccm/develop/reference/apps/sms_applicationassignment-server-wmi-class.md
@@ -330,6 +330,10 @@ Class SMS_ApplicationAssignment : SMS_CIAssignmentBaseClass
 |-|-|  
 |1|PREDEPLOY|  
 |2|ONDEMAND|  
+|4|ENABLEPROCESSTERMINATION|  
+|8|ALLOWUSERSTOREPAIRAPP|  
+|16|RELATIVESCHEDULE|  
+|32|HIGHIMPACTDEPLOYMENT|  
 
  `OfferTypeID`  
  Data type: `SInt32`  


### PR DESCRIPTION
### Summarize the change in the pull request title

Adds more possible values to the list for OfferFlags property that are disabled when looking at the class in WMIExplorer v2

Fixes https://github.com/MicrosoftDocs/SCCMdocs/issues/1180
