### PR TITLE
Update triggerschedule-method-in-class-sms_client.md

### DIFF
--- a/sccm/develop/reference/core/clients/client-classes/triggerschedule-method-in-class-sms_client.md
+++ b/sccm/develop/reference/core/clients/client-classes/triggerschedule-method-in-class-sms_client.md
@@ -69,7 +69,6 @@ UInt32 TriggerSchedule(
 |Windows Installer Source List Update Cycle|{00000000-0000-0000-0000-000000000107}|
 |Software Updates Assignments Evaluation Cycle|{00000000-0000-0000-0000-000000000108}|
 |Branch Distribution Point Maintenance Task|{00000000-0000-0000-0000-000000000109}|
-|DCM policy|{00000000-0000-0000-0000-000000000110}|
 |Send Unsent State Message|{00000000-0000-0000-0000-000000000111}|
 |State System policy cache cleanout|{00000000-0000-0000-0000-000000000112}|
 |Scan by Update Source|{00000000-0000-0000-0000-000000000113}|


### PR DESCRIPTION
Removed DCM Eval since it's no longer supported.

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
