### PR TITLE
change from def updates to security updates

### DIFF
--- a/sccm/protect/deploy-use/endpoint-definition-updates.md
+++ b/sccm/protect/deploy-use/endpoint-definition-updates.md
@@ -45,7 +45,7 @@ ms.collection: M365-identity-device-management
 
 3.  Open the properties page of the **Default Antimalware Policy** or create a new antimalware policy. For more information about how to create antimalware policies, see [How to create and deploy antimalware policies for Endpoint Protection in System Center Configuration Manager](endpoint-antimalware-policies.md).
 
-4.  In the **Definition updates** section of the antimalware properties dialog box, click **Set Source**.
+4.  In the **Security Intelligence updates** section of the antimalware properties dialog box, click **Set Source**.
 
 5.  In the **Configure Definition Update Sources** dialog box, select the sources to use for definition updates. You can click **Up** or **Down** to modify the order in which these sources are used.
 

--- a/sccm/protect/deploy-use/endpoint-definition-updates.md
+++ b/sccm/protect/deploy-use/endpoint-definition-updates.md
@@ -2,7 +2,7 @@
 title: Configure definition updates
 titleSuffix: Configuration Manager
 description: Learn how to select and configure methods with Endpoint Protection in Configuration Manager to keep antimalware definitions up to date on client computers.
-ms.date: 02/14/2017
+ms.date: 11/18/2019
 ms.prod: configuration-manager
 ms.technology: configmgr-protect
 ms.topic: conceptual
@@ -46,6 +46,7 @@ ms.collection: M365-identity-device-management
 3.  Open the properties page of the **Default Antimalware Policy** or create a new antimalware policy. For more information about how to create antimalware policies, see [How to create and deploy antimalware policies for Endpoint Protection in System Center Configuration Manager](endpoint-antimalware-policies.md).
 
 4.  In the **Security Intelligence updates** section of the antimalware properties dialog box, click **Set Source**.
+    - The **Definition updates** section was renamed to **Security Intelligence updates** starting in Configuration Manager version 1902.
 
 5.  In the **Configure Definition Update Sources** dialog box, select the sources to use for definition updates. You can click **Up** or **Down** to modify the order in which these sources are used.
 

--- a/sccm/protect/deploy-use/endpoint-definitions-microsoft-updates.md
+++ b/sccm/protect/deploy-use/endpoint-definitions-microsoft-updates.md
@@ -2,7 +2,7 @@
 title: Download definitions from Microsoft
 titleSuffix: Configuration Manager
 description: Learn how to enable the download of Endpoint Protection malware definitions from Microsoft Updates for Configuration Manager.
-ms.date: 02/14/2017
+ms.date: 11/18/2019
 ms.prod: configuration-manager
 ms.technology: configmgr-protect
 ms.topic: conceptual
@@ -17,12 +17,13 @@ ms.collection: M365-identity-device-management
 
 *Applies to: System Center Configuration Manager (Current Branch)*
 
-When you select to download definition updates from Microsoft Update, clients will check the Microsoft Update site at the interval defined in the **Definition updates** section of the antimalware policy dialog box.
+When you select to download definition updates from Microsoft Update, clients will check the Microsoft Update site at the interval defined in the **Security Intelligence updates** section of the antimalware policy dialog box.
 
  This method can be useful when the client does not have connectivity to the Configuration Manager site or when you want users to be able to initiate definition updates.
 
 > [!IMPORTANT]
->  Clients must have access to Microsoft Update on the Internet to be able to use this method to download definition updates.
+> - Clients must have access to Microsoft Update on the Internet to be able to use this method to download definition updates.
+> - The **Definition updates** section was renamed to **Security Intelligence updates** starting in Configuration Manager version 1902.
 
 ## Using the Microsoft Malware Protection Center to Download Definitions
  You can configure clients to download definition updates from the Microsoft Malware Protection Center. This option is used by Endpoint Protection clients to download definition updates if they have not been able to download updates from another source. This update method can be useful if there is a problem with your Configuration Manager infrastructure that prevents the delivery of updates.

--- a/sccm/protect/deploy-use/endpoint-definitions-network.md
+++ b/sccm/protect/deploy-use/endpoint-definitions-network.md
@@ -2,7 +2,7 @@
 title: Download definitions from a network share
 titleSuffix: Configuration Manager
 description: Learn how to manually download the latest definition updates from Microsoft and then configure clients to download these definitions.
-ms.date: 02/14/2017
+ms.date: 11/18/2019
 ms.prod: configuration-manager
 ms.technology: configmgr-protect
 ms.topic: conceptual
@@ -32,7 +32,8 @@ ms.collection: M365-identity-device-management
 
 3.  Open the properties page of the **Default Antimalware Policy** or create a new antimalware policy. For more information about how to create antimalware policies, see [How to create and deploy antimalware policies for Endpoint Protection in System Center Configuration Manager](endpoint-antimalware-policies.md).
 
-4.  In the **Definition updates** section of the antimalware properties dialog box, click **Set Source**.
+4.  In the **Security Intelligence updates** section of the antimalware properties dialog box, click **Set Source**.
+    - The **Definition updates** section was renamed to **Security Intelligence updates** starting in Configuration Manager version 1902.
 
 5.  In the **Configure Definition Update Sources** dialog box, select **Updates from UNC file shares**.
 


### PR DESCRIPTION
Definition updates are now called Security Intelligence updates.  In the list of sections to click on Definition Updates no longer exists and instead it is Security Intelligence Updates.

Attached screenshot
![Capture2](https://user-images.githubusercontent.com/19168174/68959744-ae5f5f80-079c-11ea-8ef4-f03357f647f7.PNG)


### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

Fixes #Issue_Number (if necessary)
