### PR TITLE
Extended CIType_ID with Types from SCCM 1906

### DIFF
--- a/sccm/develop/reference/compliance/sms_configurationitemlatestbaseclass-server-wmi-class.md
+++ b/sccm/develop/reference/compliance/sms_configurationitemlatestbaseclass-server-wmi-class.md
@@ -124,16 +124,22 @@ Class SMS_ConfigurationItemLatestBaseClass : SMS_BaseClass
 |6|Driver|  
 |7|OtherConfigurationItem|  
 |8|SoftwareUpdateBundle|  
-|9|SoftwareUpdateAuthorizationList|  
+|9|AuthorizationList (SoftwareUpdateAuthorizationList)|  
 |10|AppModel|  
 |11|GlobalSettings|  
 |13|GlobalExpression|  
 |14|Platform|  
 |21|DeploymentType|  
+|24|Install Policy Type|  
 |25|DeploymentTechnology|  
 |26|HostingTechnology|  
 |27|InstallerTechnology|  
-|28|AbstractConfigurationItem|  
+|28|PublishingItem|  
+|29|ApplicationGroup|  
+|40|SettingsDefinition|  
+|50|ConfigurationPolicy|  
+|60|VirtualEnvironment|  
+|70|AbstractConfigurationItem|  
 
  `CIVersion`  
  Data type: `UInt32`  


### PR DESCRIPTION
Added the following Types (as per CI_Types table in database)

24	Install Policy Type
28	PublishingItem
29	ApplicationGroup
40	SettingsDefinition
50	ConfigurationPolicy
60	VirtualEnvironment
