### PR TITLE
Extended RelationType with Types from SCCM 1906

### DIFF
--- a/sccm/develop/reference/sum/sms_cirelation-server-wmi-class.md
+++ b/sccm/develop/reference/sum/sms_cirelation-server-wmi-class.md
@@ -89,6 +89,22 @@ Class SMS_CIRelation : SMS_BaseClass
 |4|Optional|  
 |5|Derived|  
 |6|Superseded|  
+|7|Self|  
+|8|Reference|  
+|9|AppToDTReference|  
+|10|AppDependence|  
+|11|Intention|  
+|12|Platform|  
+|13|GlobalConditionReference|  
+|15|ApplicationSuperSeded||  
+|16|ApplicationType|  
+|17|ApplicationHost|  
+|18|ApplicationInstaller|  
+|19|SupersedOrDependent|  
+|20|VirtualEnvironmentReference|  
+|21|AppDCMReference|  
+|22|DeploymentTypeToPolicyTemplateReference|  
+|23|CIInheritanceRelation|  
 
  `ToCIID`  
  Data type: `UInt32`  


### PR DESCRIPTION
Added the following Types (as per CI_RelationTypes table in database)

7 Self
8 Reference
9 AppToDTReference
10 AppDependence
11 Intention
12 Platform
13 GlobalConditionReference
15 ApplicationSuperSeded 
16 ApplicationType
17 ApplicationHost
18 ApplicationInstaller
19 SupersedOrDependent
20 VirtualEnvironmentReference
21 AppDCMReference
22 DeploymentTypeToPolicyTemplateReference
23 CIInheritanceRelation
