### PR TITLE
In the Back up certificate SQL script, removed END

### DIFF
--- a/sccm/protect/deploy-use/bitlocker/encrypt-recovery-data.md
+++ b/sccm/protect/deploy-use/bitlocker/encrypt-recovery-data.md
@@ -103,7 +103,6 @@ USE CM_ABC
 BACKUP CERTIFICATE BitLockerManagement_CERT TO FILE = 'C:\BitLockerManagement_CERT'
     WITH PRIVATE KEY ( FILE = 'C:\BitLockerManagement_CERT_KEY',
         ENCRYPTION BY PASSWORD = MyExportKeyPassword)
-END
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
END is only necessary when running multiple sql statements together, and without BEGIN which was not there to begin with, END will actually throw a syntax error which it did for me when I first tried to run it

### Summarize the change in the pull request title

Describe your change, specifically *why* you think it's needed.

@aczechowski fixed BitLocker Management Back up cert script syntax error
