### PR TITLE
Add brackets to function prototype 'CategoryIds'

### DIFF
--- a/sccm/develop/reference/core/servers/configure/addmemberships-method-in-class-sms_securedcategorymembership.md
+++ b/sccm/develop/reference/core/servers/configure/addmemberships-method-in-class-sms_securedcategorymembership.md
@@ -23,7 +23,7 @@ The `AddMemberships` Windows Management Instrumentation (WMI) class method, in C
 SInt32 AddMemberships(  
      String ObjectIDs[],  
      UInt32 ObjectTypeIDs[],  
-     String CategoryIDs,  
+     String CategoryIDs[],  
 );  
 ```  
 


### PR DESCRIPTION
Add brackets to function prototype argument 'CategoryIds'.

### Summarize the change in the pull request title

The prototype of the function correctly declares both ObjectIDs and ObjectTypeIDs as arrays of Strings/Uint32 repsectively, but CategoryIDs also is a String array. If all you look at is the prototype (like I did :), you'll miss that. This makes Powershell Invoke-Method and directly calls from WMI/C# very unhappy. 
