### PR TITLE
Change "backslash" to "slash"

### DIFF
--- a/sccm/core/clients/deploy/about-client-installation-properties.md
+++ b/sccm/core/clients/deploy/about-client-installation-properties.md
@@ -35,7 +35,7 @@ Use the CCMSetup.exe command to install the Configuration Manager client. If you
 > [!NOTE]  
 >  In Configuration Manager, you can't run the Client.msi file directly.  
 
- CCMSetup.exe provides [command-line parameters](#ccmsetupexe-command-line-parameters) to customize the installation -- parameters are prefixed with a backslash and by convention are lower case. You specify the value of a parameter when necessary using a colon immediately followed by the desired value. You can also supply properties to modify the behavior of client.msi at the CCMSetup.exe command line -- properties by convention are in all upper case. You specify a value for a property using an equal sign immediately followed by the desired value.  
+ CCMSetup.exe provides [command-line parameters](#ccmsetupexe-command-line-parameters) to customize the installation -- parameters are prefixed with a slash and by convention are lower case. You specify the value of a parameter when necessary using a colon immediately followed by the desired value. You can also supply properties to modify the behavior of client.msi at the CCMSetup.exe command line -- properties by convention are in all upper case. You specify a value for a property using an equal sign immediately followed by the desired value.  
 
 > [!IMPORTANT]  
 >  Specify CCMSetup parameters before you specify properties for client.msi.  


### PR DESCRIPTION
Line 38 states the parameters are "prefixed with a backslash".  This should be "slash"

### Summarize the change in the pull request title

Backslash is not the correct character utilized in the parameters.

Fixes #Issue_Number (if necessary)
