### PR TITLE
Anti-malware warning for Run PowerShell Script TS Step

### DIFF
--- a/sccm/osd/understand/task-sequence-steps.md
+++ b/sccm/osd/understand/task-sequence-steps.md
@@ -1977,6 +1977,9 @@ This step can be run in the full OS or Windows PE. To run this step in Windows P
 > [!NOTE]  
 > PowerShell isn't enabled by default on Windows Embedded operating systems.  
 
+> [!WARNING]
+> Certain anti-malware software may inadvertently trigger events against the Configuration Manager Run PowerShell Script task sequence step. It is recommended to exclude %windir%\temp\smstspowershellscripts so that the anti-malware software permits those scripts to run without interference.
+
 To add this step in the task sequence editor, select **Add**, select **General**, and select **Run PowerShell Script**.
 
 ### Variables for Run PowerShell Script


### PR DESCRIPTION
Added warning that anti-malware software may trigger warnings against %windir%\temp\smstspowershellscripts when a Run PowerShell Script task sequence step is ran. Language used for the warning is the exact same as the warning that is on the article for Create and run scripts... https://docs.microsoft.com/en-us/configmgr/apps/deploy-use/create-deploy-scripts.

This is needed so config manager admins can show their security coworkers that scripts in this directory are from config manager and are in fact legitimate. Language used matches the warning listed in the Create and run scripts article.